### PR TITLE
Added build step after library creation that can be skipped

### DIFF
--- a/src/commands/new.rs
+++ b/src/commands/new.rs
@@ -5,6 +5,7 @@ use std::process::{exit, Command};
 
 use convert_case::{Case, Casing};
 
+use crate::command_build::build_library;
 use crate::config_utils::create_initial_config;
 use crate::definitions::CargoToml;
 use crate::file_utils::write_and_fmt;
@@ -17,7 +18,8 @@ use crate::path_utils::get_absolute_path;
 ///
 /// `name` - The name of the library.
 /// `godot_project_dir` - The relative path to the directory of the Godot project that this library of modules is for.
-pub fn create_library(name: &str, godot_project_dir: PathBuf) {
+/// `skip_build` - Indicates whether the build should be skipped after creating the library or not.
+pub fn create_library(name: &str, godot_project_dir: PathBuf, skip_build: bool) {
     log_styled_message_to_console("Creating library", ConsoleColors::WHITE);
 
     // Normalize the library name so that we can be consistent.
@@ -47,6 +49,14 @@ pub fn create_library(name: &str, godot_project_dir: PathBuf) {
 
     create_rust_modules_dir_in_godot(&godot_project_absolute_path);
     create_gdnlib_in_godot(&library_name_normalized, &godot_project_absolute_path);
+
+    log_styled_message_to_console(
+        "running initial build to generate Godot project structure",
+        ConsoleColors::CYAN,
+    );
+    if !skip_build {
+        build_library();
+    }
 
     log_styled_message_to_console("library created", ConsoleColors::GREEN);
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -45,6 +45,12 @@ enum GodotRustCli {
         /// library of components is for.
         #[structopt(parse(from_os_str))]
         godot_project_dir: PathBuf,
+
+        /// Indicates whether automatic build of the library after creation
+        /// should be skipped or not. The build is not necessary but ensures
+        /// that there's no missing dynamic library error in Godot.
+        #[structopt(long, short)]
+        skip_build: bool,
     },
 
     /// Creates a new Rust component inside the current library.
@@ -93,7 +99,8 @@ fn main() {
         GodotRustCli::New {
             name,
             godot_project_dir,
-        } => command_new::create_library(&name, godot_project_dir),
+            skip_build,
+        } => command_new::create_library(&name, godot_project_dir, skip_build),
         GodotRustCli::Create { name } => command_create::create_module(&name, false),
         GodotRustCli::Destroy { name } => command_destroy::destroy_module(&name),
         GodotRustCli::Build { watch } => {

--- a/tests/command-create.rs
+++ b/tests/command-create.rs
@@ -14,7 +14,7 @@ fn create_add_module_name_as_pascalcase_to_project_toml_modules() -> Result<(), 
   init_test();
 
   let mut cmd = Command::cargo_bin("godot-rust-cli")?;
-  cmd.arg("new").arg("platformer_modules").arg("platformer");
+  cmd.arg("new").arg("platformer_modules").arg("platformer").arg("--skip-build");
 
   cmd.assert().success();
 
@@ -45,7 +45,7 @@ fn create_add_module_mod_and_handle_to_to_lib_file() -> Result<(), Box<dyn Error
   init_test();
 
   let mut cmd = Command::cargo_bin("godot-rust-cli")?;
-  cmd.arg("new").arg("platformer_modules").arg("platformer");
+  cmd.arg("new").arg("platformer_modules").arg("platformer").arg("--skip-build");
 
   cmd.assert().success();
 
@@ -85,7 +85,7 @@ fn create_module_has_correct_initial_module_file() -> Result<(), Box<dyn Error>>
   init_test();
 
   let mut cmd = Command::cargo_bin("godot-rust-cli")?;
-  cmd.arg("new").arg("platformer_modules").arg("platformer");
+  cmd.arg("new").arg("platformer_modules").arg("platformer").arg("--skip-build");
 
   cmd.assert().success();
 
@@ -142,7 +142,7 @@ fn create_module_gdns_file_in_godot_project_rust_modules_directory() -> Result<(
   init_test();
 
   let mut cmd = Command::cargo_bin("godot-rust-cli")?;
-  cmd.arg("new").arg("platformer_modules").arg("platformer");
+  cmd.arg("new").arg("platformer_modules").arg("platformer").arg("--skip-build");
 
   cmd.assert().success();
 
@@ -196,7 +196,7 @@ fn create_module_name_casing_normalized() -> Result<(), Box<dyn Error>> {
   init_test();
 
   let mut cmd = Command::cargo_bin("godot-rust-cli")?;
-  cmd.arg("new").arg("platformer_modules").arg("platformer");
+  cmd.arg("new").arg("platformer_modules").arg("platformer").arg("--skip-build");
 
   cmd.assert().success();
 
@@ -241,7 +241,7 @@ fn create_multiple_modules_should_have_gdns_files_created() -> Result<(), Box<dy
   init_test();
 
   let mut cmd = Command::cargo_bin("godot-rust-cli")?;
-  cmd.arg("new").arg("platformer_modules").arg("platformer");
+  cmd.arg("new").arg("platformer_modules").arg("platformer").arg("--skip-build");
 
   cmd.assert().success();
 
@@ -289,7 +289,7 @@ fn create_multiple_modules_should_be_added_to_lib_file() -> Result<(), Box<dyn E
   init_test();
 
   let mut cmd = Command::cargo_bin("godot-rust-cli")?;
-  cmd.arg("new").arg("platformer_modules").arg("platformer");
+  cmd.arg("new").arg("platformer_modules").arg("platformer").arg("--skip-build");
 
   cmd.assert().success();
 

--- a/tests/command-destroy.rs
+++ b/tests/command-destroy.rs
@@ -15,7 +15,7 @@ fn destroy_remove_module_from_library_lib_file_and_godot_project_rust_modules(
   init_test();
 
   let mut cmd = Command::cargo_bin("godot-rust-cli")?;
-  cmd.arg("new").arg("platformer_modules").arg("platformer");
+  cmd.arg("new").arg("platformer_modules").arg("platformer").arg("--skip-build");
 
   cmd.assert().success();
 
@@ -66,7 +66,7 @@ fn destroy_create_five_modules_remove_two_modules() -> Result<(), Box<dyn Error>
   init_test();
 
   let mut cmd = Command::cargo_bin("godot-rust-cli")?;
-  cmd.arg("new").arg("platformer_modules").arg("platformer");
+  cmd.arg("new").arg("platformer_modules").arg("platformer").arg("--skip-build");
 
   cmd.assert().success();
 

--- a/tests/command-new.rs
+++ b/tests/command-new.rs
@@ -13,7 +13,7 @@ fn new_library_has_correct_cargo_toml() -> Result<(), Box<dyn Error>> {
   init_test();
 
   let mut cmd = Command::cargo_bin("godot-rust-cli")?;
-  cmd.arg("new").arg("platformer_modules").arg("platformer");
+  cmd.arg("new").arg("platformer_modules").arg("platformer").arg("--skip-build");
 
   cmd.assert().success();
 
@@ -36,7 +36,7 @@ fn new_godot_project_has_rust_modules_directory() -> Result<(), Box<dyn Error>> 
   init_test();
 
   let mut cmd = Command::cargo_bin("godot-rust-cli")?;
-  cmd.arg("new").arg("platformer_modules").arg("platformer");
+  cmd.arg("new").arg("platformer_modules").arg("platformer").arg("--skip-build");
 
   cmd.assert().success();
 
@@ -53,7 +53,7 @@ fn new_library_name_is_snake_case() -> Result<(), Box<dyn Error>> {
   init_test();
 
   let mut cmd = Command::cargo_bin("godot-rust-cli")?;
-  cmd.arg("new").arg("platformer-modules").arg("platformer");
+  cmd.arg("new").arg("platformer-modules").arg("platformer").arg("--skip-build");
 
   cmd.assert().success();
 
@@ -72,7 +72,7 @@ fn new_library_has_correct_project_toml() -> Result<(), Box<dyn Error>> {
   init_test();
 
   let mut cmd = Command::cargo_bin("godot-rust-cli")?;
-  cmd.arg("new").arg("platformer_modules").arg("platformer");
+  cmd.arg("new").arg("platformer_modules").arg("platformer").arg("--skip-build");
 
   cmd.assert().success();
 
@@ -96,7 +96,7 @@ fn new_has_initial_lib_file() -> Result<(), Box<dyn Error>> {
   init_test();
 
   let mut cmd = Command::cargo_bin("godot-rust-cli")?;
-  cmd.arg("new").arg("platformer_modules").arg("platformer");
+  cmd.arg("new").arg("platformer_modules").arg("platformer").arg("--skip-build");
 
   cmd.assert().success();
 
@@ -119,7 +119,7 @@ fn new_godot_project_has_correct_gdnlib_file() -> Result<(), Box<dyn Error>> {
   init_test();
 
   let mut cmd = Command::cargo_bin("godot-rust-cli")?;
-  cmd.arg("new").arg("platformer_modules").arg("platformer");
+  cmd.arg("new").arg("platformer_modules").arg("platformer").arg("--skip-build");
 
   cmd.assert().success();
 

--- a/tests/command-plugin.rs
+++ b/tests/command-plugin.rs
@@ -14,7 +14,7 @@ fn plugin_add_name_to_library_project_toml() -> Result<(), Box<dyn Error>> {
   init_test();
 
   let mut cmd = Command::cargo_bin("godot-rust-cli")?;
-  cmd.arg("new").arg("platformer_modules").arg("platformer");
+  cmd.arg("new").arg("platformer_modules").arg("platformer").arg("--skip-build");
 
   cmd.assert().success();
 
@@ -45,7 +45,7 @@ fn plugin_has_correct_plugin_cfg_in_godot_project() -> Result<(), Box<dyn Error>
   init_test();
 
   let mut cmd = Command::cargo_bin("godot-rust-cli")?;
-  cmd.arg("new").arg("platformer_modules").arg("platformer");
+  cmd.arg("new").arg("platformer_modules").arg("platformer").arg("--skip-build");
 
   cmd.assert().success();
 
@@ -87,7 +87,7 @@ fn plugin_has_correct_initial_module_file() -> Result<(), Box<dyn Error>> {
   init_test();
 
   let mut cmd = Command::cargo_bin("godot-rust-cli")?;
-  cmd.arg("new").arg("platformer_modules").arg("platformer");
+  cmd.arg("new").arg("platformer_modules").arg("platformer").arg("--skip-build");
 
   cmd.assert().success();
 
@@ -158,7 +158,7 @@ fn plugin_has_correct_gdns_file_in_godot_project_rust_modules() -> Result<(), Bo
   init_test();
 
   let mut cmd = Command::cargo_bin("godot-rust-cli")?;
-  cmd.arg("new").arg("platformer_modules").arg("platformer");
+  cmd.arg("new").arg("platformer_modules").arg("platformer").arg("--skip-build");
 
   cmd.assert().success();
 
@@ -209,7 +209,7 @@ fn plugin_mod_and_handle_added_to_lib_file() -> Result<(), Box<dyn Error>> {
   init_test();
 
   let mut cmd = Command::cargo_bin("godot-rust-cli")?;
-  cmd.arg("new").arg("platformer_modules").arg("platformer");
+  cmd.arg("new").arg("platformer_modules").arg("platformer").arg("--skip-build");
 
   cmd.assert().success();
 
@@ -244,7 +244,7 @@ fn plugin_destroy_remove_from_library_lib_file_and_godot_project_rust_modules_an
   init_test();
 
   let mut cmd = Command::cargo_bin("godot-rust-cli")?;
-  cmd.arg("new").arg("platformer_modules").arg("platformer");
+  cmd.arg("new").arg("platformer_modules").arg("platformer").arg("--skip-build");
 
   cmd.assert().success();
 
@@ -297,7 +297,7 @@ fn plugin_destroy_create_three_modules_and_two_plugins_remove_one_module_and_one
   init_test();
 
   let mut cmd = Command::cargo_bin("godot-rust-cli")?;
-  cmd.arg("new").arg("platformer_modules").arg("platformer");
+  cmd.arg("new").arg("platformer_modules").arg("platformer").arg("--skip-build");
 
   cmd.assert().success();
 


### PR DESCRIPTION
Issue #4 

Added build step after library creation that can be skipped with --skip-build flag.