### PR TITLE
Updated destroy command to allow modules to be moved

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -220,6 +220,7 @@ dependencies = [
  "structopt",
  "syn",
  "toml",
+ "walkdir",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ chrono = "0.4.19"
 dunce = "1.0.1"
 syn = { version = "1.0", features = ["full", "parsing", "printing", "visit", "visit-mut", "extra-traits"] }
 convert_case = "0.4.0"
+walkdir = "2"
 
 [dev-dependencies]
 assert_cmd = "1.0.2"


### PR DESCRIPTION
- The destroy command now looks for modules outside of the `rust_modules` directory so modules can be moved around the Godot project as desired.