### PR TITLE
Feature/plugin refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,13 @@
 ![Crates.io](https://img.shields.io/crates/v/godot-rust-cli)
 ![Crates.io](https://img.shields.io/crates/d/godot-rust-cli)
 ![Crates.io](https://img.shields.io/crates/l/godot-rust-cli)
+[![Discord](https://img.shields.io/discord/853728834519040030.svg?label=&logo=discord&logoColor=ffffff&color=7389D8&labelColor=6A7EC2)](https://discord.gg/kr9EkBp7)
 
 ## Documentation
 
-Note: Godot Rust CLI is below v1.0.0 and may contain bugs, please report any bugs as issues in the GitHub repo.
+Note: Godot Rust CLI is below v1.0.0 and may contain bugs, please report any bugs as issues in the GitHub repo or feel free to ask questions in the [Discord](https://discord.gg/kr9EkBp7).
+
+Also keep in mind that the main branch will usually be ahead of the version on [crates.io](https://crates.io/crates/godot-rust-cli).
 
 **Table of Contents**
 
@@ -24,12 +27,13 @@ Note: Godot Rust CLI is below v1.0.0 and may contain bugs, please report any bug
   - [Step By Step](#step-by-step)
 - [API](#api)
   - [new](#new)
+    - [plugin](#plugin)
   - [create](#create)
   - [destroy](#destroy)
   - [build](#build)
-  - [plugin](#plugin)
 - [Compatibility](#compatibility)
 - [Updating](#updating)
+- [Questions](#questions)
 - [License](#license)
 
 ## Introduction
@@ -169,6 +173,20 @@ godot-rust-cli new platformer_modules platformer
 
 **Note:** To make Godot Rust CLI easy to use when importing other people's projects, the library and Godot project must have the same parent directory. For example, if your Godot project is named `platformer` and it lives under a directory called `Games`, then the library of Rust modules must also be created in the `Games` directory.
 
+### plugin
+
+The `new` command can also be used to create a plugin. A plugin is itself a library and should only contain modules necessary for that plugin. A plugin has the same arguments as `new`, since it is an extension of the `new` command but you have to pass `plugin` as a flag.
+
+**Example:**
+
+Creating a library for a plugin named "Directory Browser" for a Godot project named `platformer`.
+
+```sh
+godot-rust-cli new "Directory Browser" platformer --plugin
+```
+
+**Note:** The plugin doesn't have to be tied to a Godot project outside of just using it for development/testing. All of the plugin's files are contained with the plugin itself and it can be moved around after development on it is finished.
+
 ### create
 
 Creates a Rust module and it's corresponding file structure in the library and the Godot project.
@@ -198,6 +216,8 @@ godot-rust-cli create MainScene
 ```
 
 **Note:** The name of the module to create should be PascalCase and Godot Rust CLI will attempt to normalize it for you. However, in cases where the module name is multiple words like `MainScene`, and if you use `mainscene`, then it will not be normalized correctly so you should try to use the correct casing whenever possible.
+
+**Note:** All modules will be placed in a `rust_modules` directory in the Godot project by default but you can move it wherever you need it.
 
 ### destroy
 
@@ -249,28 +269,6 @@ Building the library and watching for changes to the library to rebuild automati
 godot-rust-cli build --watch
 ```
 
-### plugin
-
-Creates a module meant to be used as a plugin. This works about the same as `create` but this also creates the `addons` structure in the Godot project that Godot requires from plugins.
-
-**Usage:**
-
-```sh
-godot-rust-cli plugin <plugin_name>
-```
-
-where:
-
-- `plugin_name` is the name of the plugin. This should be the user friendly name of the plugin and Godot Rust CLI will handle normalizing it, like the example below.
-
-**Examples:**
-
-Creating a plugin named Directory Browser:
-
-```sh
-godot-rust-cli plugin "Directory Browser"
-```
-
 # Compatibility
 
 | Godot Rust Version | Godot Rust CLI Version |
@@ -282,7 +280,19 @@ godot-rust-cli plugin "Directory Browser"
 
 ## 0.1.x to 0.2.x
 
-To update your project to be compatible with 0.2.x versions from 0.1.x versions, you will need to rename your `project.toml` file to `godot-rust-cli.json`.
+To update your project to be compatible with 0.2.x versions from 0.1.x versions, you will need to rename your `project.toml` file to `godot-rust-cli.toml`.
+
+## 0.2.x to 0.3.x
+
+Libraries have switched from a toml config to a json config so if you want to update your library it is recommended to check out what the json config looks like and update your local one to match. 
+
+A tool is in development to make upgrading between major changes easier. If you need help, questions and concerns are always welcome on [Discord](https://discord.gg/kr9EkBp7).
+
+If you have been developing a plugin, there is unfortunately no way to upgrade without creating a new project as there was a major overhaul to plugin creation.
+
+# Questions
+
+Check out the [Discord](https://discord.gg/kr9EkBp7) to ask any questions or concerns about the cli or Godot + Rust in general.
 
 ## License
 

--- a/src/commands/build.rs
+++ b/src/commands/build.rs
@@ -47,6 +47,8 @@ pub fn build_library() {
         dynamic_library_ext
     );
     let dynamic_library_file = dynamic_libraries_path.join(dynamic_library_file_name);
+    // The path to the Godot project.
+    let godot_project_dir = parent_dir.join(&config.godot_project_name);
 
     log_version();
     log_styled_message_to_console("building...", ConsoleColors::CYAN);
@@ -56,13 +58,18 @@ pub fn build_library() {
 
     // The path to where the dynamic libraries should be stored in the Godot
     // project directory.
-    let bin_path = parent_dir.join(&config.godot_project_name).join("bin");
+    let bin_path = if config.is_plugin {
+        godot_project_dir
+            .join("addons")
+            .join(&config.name.to_case(Case::Snake))
+            .join("bin")
+    } else {
+        parent_dir.join(&config.godot_project_name).join("bin")
+    };
 
     // Create the `bin` folder in the Godot project if it doesn't already exist.
     create_dir_all(&bin_path).expect("Unable to create bin directory in the Godot project");
 
-    // Copy the dynamic library created from the build to the `bin` directory
-    // in the Godot project.
     copy_file_to_location(&dynamic_library_file, &bin_path);
 
     log_styled_message_to_console("Build complete", ConsoleColors::GREEN);

--- a/src/commands/create.rs
+++ b/src/commands/create.rs
@@ -4,21 +4,27 @@ use std::path::PathBuf;
 
 use convert_case::{Case, Casing};
 
-use crate::config_utils::{add_module_to_config, get_config_as_object, is_module_in_config};
+use crate::config_utils::{
+    add_module_to_config, get_config_as_object, is_module_in_config, Config,
+};
 use crate::file_utils::write_and_fmt;
 use crate::lib_utils::add_module_to_lib;
 use crate::log_utils::{log_styled_message_to_console, ConsoleColors};
-use crate::path_utils::{exit_if_not_lib_dir, get_library_name_from_path};
+use crate::path_utils::exit_if_not_lib_dir;
 
 /// Creates a new Rust module inside the library.
 ///
 /// # Arguments
 ///
 /// `name` - The name of the module to create. The module name should be PascalCase with examples including 'Player', 'Princess', 'Mob', etc.
-/// `is_plugin` - Indicates whether the module is for a plugin or not.
-pub fn create_module(name: &str, is_plugin: bool) {
+pub fn create_module(name: &str) {
     // Exit early if this command is not being run from the library directory.
     exit_if_not_lib_dir();
+
+    // We need the name of the module to create as snake case for file names
+    // and as pascal case for config.
+    let module_name_snake_case = &name.to_case(Case::Snake);
+    let module_name_pascal_case = &name.to_case(Case::Pascal);
 
     // Get the parent directory since it always contains both the library and Godot project.
     let current_dir = current_dir().expect("Unable to get current directory");
@@ -41,75 +47,45 @@ pub fn create_module(name: &str, is_plugin: bool) {
         );
     }
     // Create the `module.mod` file for the module in the library directory.
-    create_initial_module_file(name, is_plugin);
+    create_initial_module_file(
+        module_name_snake_case,
+        module_name_pascal_case,
+        config.is_plugin,
+    );
 
     // Add the `mod` and turbofish handle to the `src/lib.rs` file in the
     // library directory.
-    add_module_to_lib(name, is_plugin, &config);
+    add_module_to_lib(name, &config);
 
     // Create the gdns file for the module in the Godot project directory.
     // Note that this puts the gdns file in the `rust_modules` directory by
     // default but since the modules reference the gdnlib file in the root
     // of the Godot project, it can be moved anywhere.
-    create_gdns_file_in_godot_project(name, &config.godot_project_name);
-
-    if is_plugin {
-        // If this module is a plugin, then we need to create the plugin
-        // structure in the Godot project.
-        create_plugin_structure_in_godot_project(name, &path_to_godot_project)
-    }
+    create_gdns_file_in_godot(
+        module_name_snake_case,
+        module_name_pascal_case,
+        &path_to_godot_project,
+        &config,
+    );
 
     // Adds the module to the `modules` section of the config and saves it.
-    let module_name_pascal_case = &name.to_case(Case::Pascal);
-    add_module_to_config(module_name_pascal_case, &mut config);
+    add_module_to_config(name, &mut config);
 
     log_styled_message_to_console("Module created", ConsoleColors::GREEN);
-}
-
-/// Creates the plugin structure within the Godot project.
-///
-/// `godot_project_path` - The path to the Godot project.
-/// `module_name` - The name of the plugin module to create.
-/// `normalized_module_name` - The normalized name of the plugin module to create.
-fn create_plugin_structure_in_godot_project(module_name: &str, godot_project_path: &PathBuf) {
-    // Normalize the module name because we want directories and files in the
-    // Godot project to be lowercase due to standards.
-    let module_name_snake_case = &module_name.to_case(Case::Snake);
-
-    // Create the directory for the plugin and the necessary `plugin.cfg` file
-    // required by Godot.
-    let godot_plugin_dir = godot_project_path
-        .join("addons")
-        .join(&module_name_snake_case);
-    let godot_plugin_cfg = godot_plugin_dir.join("plugin.cfg");
-    std::fs::create_dir_all(&godot_plugin_dir)
-        .expect("Unable to create plugin directory structure in Godot project");
-
-    // Create the config file for the plugin and replace the template values
-    // with the plugin's values.
-    let plugin_cfg = include_str!("../templates/plugin-cfg.txt");
-    let plugin_cfg_with_name = plugin_cfg.replace("PLUGIN_NAME", &module_name);
-    let plugin_cfg_with_script = plugin_cfg_with_name.replace(
-        "PLUGIN_GDNS_LOCATION",
-        &format!("../../rust_modules/{}.gdns", &module_name_snake_case),
-    );
-    write(godot_plugin_cfg, plugin_cfg_with_script).expect("Unable to write plugin.cfg file");
 }
 
 /// Creates the initial module file with the template.
 ///
 /// # Arguments
 ///
-/// `module_name` - The name of the module to create.
+/// `module_name_snake_case` - The snake case version of the name of the module to create.
+/// `module_name_pascal_case` - The pascal case version of the name of the module to create.
 /// `is_plugin` - Indicates whether the module is a plugin or not.
-fn create_initial_module_file(module_name: &str, is_plugin: bool) {
-    // We need two variations of the module name to create the mod file, the
-    // snake case version and the pascal case version. The snake case version
-    // is used to create the module's file name while the pascal case version
-    // is used in the module template file.
-    let module_name_snake_case = &module_name.to_case(Case::Snake);
-    let module_name_pascal_case = &module_name.to_case(Case::Pascal);
-
+fn create_initial_module_file(
+    module_name_snake_case: &str,
+    module_name_pascal_case: &str,
+    is_plugin: bool,
+) {
     // Get the template for the module depending whether it's a regular module
     // or a plugin module.
     let mod_template = if is_plugin {
@@ -132,40 +108,54 @@ fn create_initial_module_file(module_name: &str, is_plugin: bool) {
 /// Creates the gdns file for the module and writes it to the Godot project
 /// directory.
 ///
-/// `module_name` - The name of the module to create.
-/// `godot_project_name` - The name of the project.
-/// `parent_dir` - The parent directory.
-/// `module_name_snake_case` - The snake_case version of the module name.
-/// `module_name_pascal_case` - The PascalCase version of the module to check if already exists.
-fn create_gdns_file_in_godot_project(module_name: &str, godot_project_name: &String) {
-    // We need two versions of the module name, the snake case version for the
-    // gdns file name and the pascal version for replacing the module's name in
-    // the gdns file template.
-    let module_name_snake_case = &module_name.to_case(Case::Snake);
-    let module_name_pascal_case = &module_name.to_case(Case::Pascal);
-
-    // Get the name of the library.
-    let lib_name = get_library_name_from_path();
-
-    // Get the parent directory so that we can create paths to the Godot
-    // project since the parent directory contains both the library and the
-    // Godot project.
-    let current_dir = current_dir().expect("Unable to get current directory");
-    let parent_dir = current_dir.parent().expect("Unable to get parent dir");
-
+/// `module_name_snake_case` - The snake case version of the name of the module to create.
+/// `module_name_pascal_case` - The pascal case version of the name of the module to create.
+/// `godot_project_dir` - The path to the Godot project.
+/// `is_plugin` - Indicates whether the module is for a plugin for not.
+fn create_gdns_file_in_godot(
+    module_name_snake_case: &str,
+    module_name_pascal_case: &str,
+    godot_project_dir: &PathBuf,
+    config: &Config,
+) {
     // Create the path to the gdns file in the Godot project by joining the
     // path to the Godot project with the default `rust_modules` directory.
     let gdns_file_name = format!("{}.gdns", &module_name_snake_case);
-    let gdns_path = parent_dir
-        .join(&godot_project_name)
-        .join("rust_modules")
-        .join(gdns_file_name);
+    let library_name_snake_dir = &config.name.to_case(Case::Snake);
 
-    // Get the template for the gdns file and replace the values with the
-    // module name.
+    let gdns_path: PathBuf = if config.is_plugin {
+        // Since the library is a plugin, we check to first check whether the
+        // `rust_modules` directory exists in the Godot project or not. If it
+        // does then we write the gdns file that, otherwise we write it to the
+        // root of the plugin directory.
+        let plugin_rust_modules_dir = godot_project_dir
+            .join("addons")
+            .join(&library_name_snake_dir)
+            .join("rust_modules");
+        if plugin_rust_modules_dir.exists() {
+            plugin_rust_modules_dir.join(gdns_file_name)
+        } else {
+            godot_project_dir
+                .join("addons")
+                .join(&library_name_snake_dir)
+                .join(gdns_file_name)
+        }
+    } else {
+        godot_project_dir.join("rust_modules").join(gdns_file_name)
+    };
+
+    let gdns_library_path = if config.is_plugin {
+        format!(
+            "addons/{}/{}",
+            &library_name_snake_dir, &library_name_snake_dir
+        )
+    } else {
+        format!("{}", &library_name_snake_dir)
+    };
+
     let gdns_template = include_str!("../templates/gdns.txt");
     let gdns_with_module_name = gdns_template
-        .replace("LIBRARY_NAME", &lib_name.to_case(Case::Snake))
+        .replace("LIBRARY_PATH", &gdns_library_path)
         .replace("MODULE_NAME", &module_name_pascal_case);
 
     write(gdns_path, gdns_with_module_name).expect("Unable to create module's gdns file");

--- a/src/commands/create.rs
+++ b/src/commands/create.rs
@@ -121,7 +121,7 @@ fn create_gdns_file_in_godot(
     // Create the path to the gdns file in the Godot project by joining the
     // path to the Godot project with the default `rust_modules` directory.
     let gdns_file_name = format!("{}.gdns", &module_name_snake_case);
-    let library_name_snake_dir = &config.name.to_case(Case::Snake);
+    let library_name_snake_case = &config.name.to_case(Case::Snake);
 
     let gdns_path: PathBuf = if config.is_plugin {
         // Since the library is a plugin, we check to first check whether the
@@ -130,14 +130,14 @@ fn create_gdns_file_in_godot(
         // root of the plugin directory.
         let plugin_rust_modules_dir = godot_project_dir
             .join("addons")
-            .join(&library_name_snake_dir)
+            .join(&library_name_snake_case)
             .join("rust_modules");
         if plugin_rust_modules_dir.exists() {
             plugin_rust_modules_dir.join(gdns_file_name)
         } else {
             godot_project_dir
                 .join("addons")
-                .join(&library_name_snake_dir)
+                .join(&library_name_snake_case)
                 .join(gdns_file_name)
         }
     } else {
@@ -147,10 +147,10 @@ fn create_gdns_file_in_godot(
     let gdns_library_path = if config.is_plugin {
         format!(
             "addons/{}/{}",
-            &library_name_snake_dir, &library_name_snake_dir
+            &library_name_snake_case, &library_name_snake_case
         )
     } else {
-        format!("{}", &library_name_snake_dir)
+        format!("{}", &library_name_snake_case)
     };
 
     let gdns_template = include_str!("../templates/gdns.txt");

--- a/src/commands/destroy.rs
+++ b/src/commands/destroy.rs
@@ -1,6 +1,7 @@
 use std::env::current_dir;
 use std::fs::{read_to_string, remove_file};
 use std::path::{Path, PathBuf};
+use std::process::exit;
 
 use convert_case::{Case, Casing};
 use walkdir::WalkDir;

--- a/src/commands/destroy.rs
+++ b/src/commands/destroy.rs
@@ -1,7 +1,6 @@
 use std::env::current_dir;
 use std::fs::{read_to_string, remove_file};
 use std::path::{Path, PathBuf};
-use std::process::exit;
 
 use convert_case::{Case, Casing};
 use walkdir::WalkDir;

--- a/src/commands/new.rs
+++ b/src/commands/new.rs
@@ -6,6 +6,7 @@ use std::process::{exit, Command};
 use convert_case::{Case, Casing};
 
 use crate::command_build::build_library;
+use crate::command_create::create_module;
 use crate::config_utils::{create_initial_config, Config};
 use crate::definitions::CargoToml;
 use crate::file_utils::write_and_fmt;
@@ -253,11 +254,7 @@ fn create_plugin_structure_in_godot(plugin_name: &str, godot_project_path: &Path
     create_dir_all(&godot_plugin_dir)
         .expect("Unable to create plugin directory structure in Godot project");
 
-    Command::new("godot-rust-cli")
-        .arg("create")
-        .arg(&plugin_name)
-        .status()
-        .expect("Unable to create plugin module");
+    create_module(&plugin_name);
 
     let plugin_cfg = include_str!("../templates/plugin-cfg.txt");
     let plugin_cfg_with_name = plugin_cfg.replace("PLUGIN_NAME", &plugin_name);

--- a/src/main.rs
+++ b/src/main.rs
@@ -48,6 +48,10 @@ enum GodotRustCli {
         #[structopt(parse(from_os_str))]
         godot_project_dir: PathBuf,
 
+        /// Indicates whether the library is for a plugin or not.
+        #[structopt(long, short)]
+        plugin: bool,
+
         /// Indicates whether automatic build of the library after creation
         /// should be skipped or not. The build is not necessary but ensures
         /// that there's no missing dynamic library error in Godot.
@@ -85,15 +89,6 @@ enum GodotRustCli {
         #[structopt(long, short)]
         watch: bool,
     },
-
-    /// Creates a plugin in the library and Godot project.
-    ///
-    /// Usage: godot-rust-cli plugin "Toml Parser"
-    Plugin {
-        /// The name of the plugin.
-        #[structopt()]
-        name: String,
-    },
 }
 
 fn main() {
@@ -101,9 +96,10 @@ fn main() {
         GodotRustCli::New {
             name,
             godot_project_dir,
+            plugin,
             skip_build,
-        } => command_new::create_library(&name, godot_project_dir, skip_build),
-        GodotRustCli::Create { name } => command_create::create_module(&name, false),
+        } => command_new::create_library(&name, godot_project_dir, plugin, skip_build),
+        GodotRustCli::Create { name } => command_create::create_module(&name),
         GodotRustCli::Destroy { name } => command_destroy::destroy_module(&name),
         GodotRustCli::Build { watch } => {
             if watch {
@@ -112,6 +108,5 @@ fn main() {
                 command_build::build_library();
             }
         }
-        GodotRustCli::Plugin { name } => command_create::create_module(&name, true),
     }
 }

--- a/src/templates/gdnlib.txt
+++ b/src/templates/gdnlib.txt
@@ -7,9 +7,9 @@ reloadable=true
 
 [entry]
 
-OSX.64="res://bin/libLIBRARY_NAME.dylib"
-Windows.64="res://bin/LIBRARY_NAME.dll"
-X11.64="res://bin/libLIBRARY_NAME.so"
+OSX.64="res://LIBRARY_PATH/libLIBRARY_NAME.dylib"
+Windows.64="res://LIBRARY_PATH/LIBRARY_NAME.dll"
+X11.64="res://LIBRARY_PATH/libLIBRARY_NAME.so"
 
 [dependencies]
 

--- a/src/templates/gdns.txt
+++ b/src/templates/gdns.txt
@@ -1,6 +1,6 @@
 [gd_resource type="NativeScript" load_steps=2 format=2]
 
-[ext_resource path="res://LIBRARY_NAME.gdnlib" type="GDNativeLibrary" id=1]
+[ext_resource path="res://LIBRARY_PATH.gdnlib" type="GDNativeLibrary" id=1]
 
 [resource]
 

--- a/src/utils/config.rs
+++ b/src/utils/config.rs
@@ -5,6 +5,8 @@ use std::fs::write;
 use std::path::{Path, PathBuf};
 use std::process::exit;
 
+use convert_case::{Case, Casing};
+
 use crate::log_utils::{log_styled_message_to_console, ConsoleColors};
 
 /// The stucture of the configuration file.
@@ -33,7 +35,11 @@ pub fn get_path_to_config_file() -> PathBuf {
 /// `library_name` - The name of the library.
 /// `godot_project_name` - The name of the Godot project.
 /// `is_library` - Indicates whether the library is for a plugin or not.
-pub fn create_initial_config(library_name: String, godot_project_name: String, is_plugin: bool) -> Config {
+pub fn create_initial_config(
+    library_name: String,
+    godot_project_name: String,
+    is_plugin: bool,
+) -> Config {
     let config = Config {
         name: library_name,
         godot_project_name: godot_project_name,
@@ -83,6 +89,17 @@ pub fn save_config_to_file(config: &mut Config) {
 /// `module_name` - The name of the module to add to the configuration file.
 /// `config` - Can be passed if the config is already in memory.
 pub fn add_module_to_config(module_name: &str, config: &mut Config) {
+    // If the library is for a plugin, and the module is the root plugin module,
+    // we don't add it to the config since it can't be removed.
+    if config.is_plugin {
+        let config_name_snake_case = &config.name.to_case(Case::Snake);
+        let module_name_snake_case = &module_name.to_case(Case::Snake);
+
+        if module_name_snake_case == config_name_snake_case {
+            return;
+        }
+    }
+
     config.modules.push(module_name.to_string());
     save_config_to_file(config);
 }

--- a/src/utils/config.rs
+++ b/src/utils/config.rs
@@ -10,8 +10,12 @@ use crate::log_utils::{log_styled_message_to_console, ConsoleColors};
 /// The stucture of the configuration file.
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct Config {
+    /// The name of the library.
+    pub name: String,
     /// The name of the directory of the Godot project.
     pub godot_project_name: String,
+    /// Indicates whether the library is for a plugin or not.
+    pub is_plugin: bool,
     /// Tracks the modules created and destroyed through the cli.
     pub modules: Vec<String>,
 }
@@ -26,16 +30,22 @@ pub fn get_path_to_config_file() -> PathBuf {
 ///
 /// # Arguments
 ///
+/// `library_name` - The name of the library.
 /// `godot_project_name` - The name of the Godot project.
-pub fn create_initial_config(godot_project_name: String) {
+/// `is_library` - Indicates whether the library is for a plugin or not.
+pub fn create_initial_config(library_name: String, godot_project_name: String, is_plugin: bool) -> Config {
     let config = Config {
+        name: library_name,
         godot_project_name: godot_project_name,
+        is_plugin: is_plugin,
         modules: vec![],
     };
     let config_as_json =
         serde_json::to_string_pretty(&config).expect("Unable to create initial configuration");
 
     write("godot-rust-cli.json", config_as_json).expect("Unable to create configuration file");
+
+    return config;
 }
 
 /// Returns the configuration as an object that can be operated on.

--- a/src/utils/lib.rs
+++ b/src/utils/lib.rs
@@ -61,9 +61,8 @@ pub fn get_insert_location(
 /// Adds a module to the lib.rs file.
 ///
 /// `module_name` - The name of the module to add.
-/// `is_plugin` - Indicates whether the module is a plugin or not.
 /// `config` - The config to use.
-pub fn add_module_to_lib(module_name: &str, is_plugin: bool, config: &Config) {
+pub fn add_module_to_lib(module_name: &str, config: &Config) {
     let mut lib_file_contents = get_lib_file_contents();
 
     // The position of where we should insert the `mod` statement for the
@@ -91,7 +90,7 @@ pub fn add_module_to_lib(module_name: &str, is_plugin: bool, config: &Config) {
     // Insert the module or plugin turbofish at the start of the init function or
     // after the last module's turbofish.
     let module_name_pascal_case = &module_name.to_case(Case::Pascal);
-    let handle_line = if is_plugin {
+    let handle_line = if config.is_plugin {
         format!(
             "handle.add_tool_class::<{}::{}>();",
             &module_name_snake_case, module_name_pascal_case

--- a/tests/command-build.rs
+++ b/tests/command-build.rs
@@ -1,46 +1,46 @@
-use assert_cmd::prelude::*;
+// use assert_cmd::prelude::*;
 
-use std::env::set_current_dir;
-use std::error::Error;
-use std::path::Path;
-use std::process::Command;
+// use std::env::set_current_dir;
+// use std::error::Error;
+// use std::path::Path;
+// use std::process::Command;
 
-mod test_utilities;
-use test_utilities::{cleanup_test_files, init_test, BUILD_FILE_NAME};
+// mod test_utilities;
+// use test_utilities::{cleanup_test_files, init_test, BUILD_FILE_NAME};
 
-#[test]
-fn build_should_create_dynamic_library_file_in_godot_project_bin_directory(
-) -> Result<(), Box<dyn Error>> {
-  init_test();
+// #[test]
+// fn build_should_create_dynamic_library_file_in_godot_project_bin_directory(
+// ) -> Result<(), Box<dyn Error>> {
+//   init_test();
 
-  let mut cmd = Command::cargo_bin("godot-rust-cli")?;
-  cmd.arg("new").arg("platformer_modules").arg("platformer");
+//   let mut cmd = Command::cargo_bin("godot-rust-cli")?;
+//   cmd.arg("new").arg("platformer_modules").arg("platformer");
 
-  cmd.assert().success();
+//   cmd.assert().success();
 
-  set_current_dir("platformer_modules").expect("Unable to change to library directory");
-  Command::new("cargo")
-    .arg("run")
-    .arg("--manifest-path=../../Cargo.toml")
-    .arg("create")
-    .arg("Player")
-    .output()
-    .expect("Unable to execute cargo run");
-  Command::new("cargo")
-    .arg("run")
-    .arg("--manifest-path=../../Cargo.toml")
-    .arg("build")
-    .output()
-    .expect("Unable to execute cargo run");
+//   set_current_dir("platformer_modules").expect("Unable to change to library directory");
+//   Command::new("cargo")
+//     .arg("run")
+//     .arg("--manifest-path=../../Cargo.toml")
+//     .arg("create")
+//     .arg("Player")
+//     .output()
+//     .expect("Unable to execute cargo run");
+//   Command::new("cargo")
+//     .arg("run")
+//     .arg("--manifest-path=../../Cargo.toml")
+//     .arg("build")
+//     .output()
+//     .expect("Unable to execute cargo run");
 
-  let build_file_name = format!("../platformer/bin/{}", BUILD_FILE_NAME);
-  let build_file_path = Path::new(&build_file_name);
+//   let build_file_name = format!("../platformer/bin/{}", BUILD_FILE_NAME);
+//   let build_file_path = Path::new(&build_file_name);
 
-  assert_eq!(build_file_path.exists(), true);
+//   assert_eq!(build_file_path.exists(), true);
 
-  set_current_dir("../").expect("Unable to change to parent directory");
+//   set_current_dir("../").expect("Unable to change to parent directory");
 
-  cleanup_test_files();
+//   cleanup_test_files();
 
-  Ok(())
-}
+//   Ok(())
+// }

--- a/tests/command-create.rs
+++ b/tests/command-create.rs
@@ -1,363 +1,298 @@
-// use assert_cmd::prelude::*;
-
-// use serde_json::Value;
-// use std::env::set_current_dir;
-// use std::error::Error;
-// use std::fs::read_to_string;
-// use std::path::Path;
-// use std::process::Command;
-
-// mod test_utilities;
-// use test_utilities::{cleanup_test_files, init_test};
-
-// #[test]
-// fn create_add_module_name_as_pascalcase_to_project_toml_modules() -> Result<(), Box<dyn Error>> {
-//     init_test();
-
-//     let mut cmd = Command::cargo_bin("godot-rust-cli")?;
-//     cmd.arg("new")
-//         .arg("platformer_modules")
-//         .arg("platformer")
-//         .arg("--skip-build");
-
-//     cmd.assert().success();
-
-//     set_current_dir("platformer_modules").expect("Unable to change to library directory");
-//     Command::new("cargo")
-//         .arg("run")
-//         .arg("--manifest-path=../../Cargo.toml")
-//         .arg("create")
-//         .arg("Player")
-//         .output()
-//         .expect("Unable to execute cargo run");
-
-//     let config = read_to_string("godot-rust-cli.json").expect("Unable to read config");
-//     let v: Value = serde_json::from_str(&config)?;
-
-//     assert_eq!(v["godot_project_name"], "platformer");
-//     assert_eq!(v["modules"][0], "Player");
-
-//     set_current_dir("../").expect("Unable to change to parent directory");
-
-//     cleanup_test_files();
-
-//     Ok(())
-// }
-
-// #[test]
-// fn create_add_module_mod_and_handle_to_to_lib_file() -> Result<(), Box<dyn Error>> {
-//     init_test();
-
-//     let mut cmd = Command::cargo_bin("godot-rust-cli")?;
-//     cmd.arg("new")
-//         .arg("platformer_modules")
-//         .arg("platformer")
-//         .arg("--skip-build");
-
-//     cmd.assert().success();
-
-//     set_current_dir("platformer_modules").expect("Unable to change to library directory");
-//     Command::new("cargo")
-//         .arg("run")
-//         .arg("--manifest-path=../../Cargo.toml")
-//         .arg("create")
-//         .arg("Player")
-//         .output()
-//         .expect("Unable to execute cargo run");
-
-//     let lib_file = read_to_string("src/lib.rs").expect("Unable to read lib file");
-//     let lib_file_split = lib_file.split("\n").collect::<Vec<&str>>();
-
-//     assert_eq!(lib_file_split[0], "mod player;");
-//     assert_eq!(lib_file_split[1], "use gdnative::prelude::*;");
-//     assert_eq!(lib_file_split[2], "");
-//     assert_eq!(lib_file_split[3], "fn init(handle: InitHandle) {");
-//     assert_eq!(
-//         lib_file_split[4].trim(),
-//         "handle.add_class::<player::Player>();"
-//     );
-//     assert_eq!(lib_file_split[5], "}");
-//     assert_eq!(lib_file_split[6], "");
-//     assert_eq!(lib_file_split[7], "godot_init!(init);");
-
-//     set_current_dir("../").expect("Unable to change to parent directory");
-
-//     cleanup_test_files();
-
-//     Ok(())
-// }
-
-// #[test]
-// fn create_module_has_correct_initial_module_file() -> Result<(), Box<dyn Error>> {
-//     init_test();
-
-//     let mut cmd = Command::cargo_bin("godot-rust-cli")?;
-//     cmd.arg("new")
-//         .arg("platformer_modules")
-//         .arg("platformer")
-//         .arg("--skip-build");
-
-//     cmd.assert().success();
-
-//     set_current_dir("platformer_modules").expect("Unable to change to library directory");
-//     Command::new("cargo")
-//         .arg("run")
-//         .arg("--manifest-path=../../Cargo.toml")
-//         .arg("create")
-//         .arg("Player")
-//         .output()
-//         .expect("Unable to execute cargo run");
-
-//     let mod_file = read_to_string("src/player.rs").expect("Unable to read module file");
-//     let mod_file_split = mod_file.split("\n").collect::<Vec<&str>>();
-
-//     assert_eq!(mod_file_split[0].trim(), "use gdnative::api::Node2D;");
-//     assert_eq!(mod_file_split[1].trim(), "use gdnative::prelude::*;");
-//     assert_eq!(mod_file_split[2].trim(), "");
-//     assert_eq!(mod_file_split[3].trim(), "#[inherit(Node2D)]");
-//     assert_eq!(mod_file_split[4].trim(), "#[derive(NativeClass)]");
-//     assert_eq!(mod_file_split[5].trim(), "pub struct Player;");
-//     assert_eq!(mod_file_split[6].trim(), "");
-//     assert_eq!(mod_file_split[7].trim(), "#[methods]");
-//     assert_eq!(mod_file_split[8].trim(), "impl Player {");
-//     assert_eq!(
-//         mod_file_split[9].trim(),
-//         "fn new(_owner: &Node2D) -> Self {"
-//     );
-//     assert_eq!(mod_file_split[10].trim(), "Player {}");
-//     assert_eq!(mod_file_split[11].trim(), "}");
-//     assert_eq!(mod_file_split[12].trim(), "#[export]");
-//     assert_eq!(
-//         mod_file_split[13].trim(),
-//         "fn _ready(&mut self, _owner: &Node2D) {"
-//     );
-//     assert_eq!(mod_file_split[14].trim(), "godot_print!(\"Hello world!\");");
-//     assert_eq!(mod_file_split[15].trim(), "}");
-//     assert_eq!(mod_file_split[16].trim(), "");
-//     assert_eq!(mod_file_split[17].trim(), "#[export]");
-//     assert_eq!(
-//         mod_file_split[18].trim(),
-//         "fn _process(&mut self, _owner: &Node2D, _delta: f32) {}"
-//     );
-
-//     set_current_dir("../").expect("Unable to change to parent directory");
-
-//     cleanup_test_files();
-
-//     Ok(())
-// }
-
-// #[test]
-// fn create_module_gdns_file_in_godot_project_rust_modules_directory() -> Result<(), Box<dyn Error>> {
-//     init_test();
-
-//     let mut cmd = Command::cargo_bin("godot-rust-cli")?;
-//     cmd.arg("new")
-//         .arg("platformer_modules")
-//         .arg("platformer")
-//         .arg("--skip-build");
-
-//     cmd.assert().success();
-
-//     set_current_dir("platformer_modules").expect("Unable to change to library directory");
-//     Command::new("cargo")
-//         .arg("run")
-//         .arg("--manifest-path=../../Cargo.toml")
-//         .arg("create")
-//         .arg("Player")
-//         .output()
-//         .expect("Unable to execute cargo run");
-
-//     let gdns_file_contents =
-//         read_to_string("../platformer/rust_modules/player.gdns").expect("Unable to read gdns file");
-//     let gdns_file_contents_split = gdns_file_contents.split("\n").collect::<Vec<&str>>();
-
-//     assert_eq!(
-//         gdns_file_contents_split[0].trim(),
-//         "[gd_resource type=\"NativeScript\" load_steps=2 format=2]"
-//     );
-//     assert_eq!(gdns_file_contents_split[1].trim(), "");
-//     assert_eq!(
-//         gdns_file_contents_split[2].trim(),
-//         "[ext_resource path=\"res://platformer_modules.gdnlib\" type=\"GDNativeLibrary\" id=1]"
-//     );
-//     assert_eq!(gdns_file_contents_split[3].trim(), "");
-//     assert_eq!(gdns_file_contents_split[4].trim(), "[resource]");
-//     assert_eq!(gdns_file_contents_split[5].trim(), "");
-//     assert_eq!(
-//         gdns_file_contents_split[6].trim(),
-//         "resource_name = \"Player\""
-//     );
-//     assert_eq!(
-//         gdns_file_contents_split[7].trim(),
-//         "class_name = \"Player\""
-//     );
-//     assert_eq!(
-//         gdns_file_contents_split[8].trim(),
-//         "library = ExtResource( 1 )"
-//     );
-
-//     set_current_dir("../").expect("Unable to change to parent directory");
-
-//     cleanup_test_files();
-
-//     Ok(())
-// }
-
-// #[test]
-// fn create_module_name_casing_normalized() -> Result<(), Box<dyn Error>> {
-//     init_test();
-
-//     let mut cmd = Command::cargo_bin("godot-rust-cli")?;
-//     cmd.arg("new")
-//         .arg("platformer_modules")
-//         .arg("platformer")
-//         .arg("--skip-build");
-
-//     cmd.assert().success();
-
-//     set_current_dir("platformer_modules").expect("Unable to change to library directory");
-//     Command::new("cargo")
-//         .arg("run")
-//         .arg("--manifest-path=../../Cargo.toml")
-//         .arg("create")
-//         .arg("MainScene")
-//         .output()
-//         .expect("Unable to execute cargo run");
-
-//     let config = read_to_string("godot-rust-cli.json").expect("Unable to read config");
-//     let v: Value = serde_json::from_str(&config)?;
-
-//     let mod_file = read_to_string("src/main_scene.rs").expect("Unable to read module file");
-//     let lib_file = read_to_string("src/lib.rs").expect("Unable to read lib file");
-
-//     let mod_file_split = mod_file.split("\n").collect::<Vec<&str>>();
-//     let lib_file_split = lib_file.split("\n").collect::<Vec<&str>>();
-
-//     assert_eq!(mod_file_split[5].trim(), "pub struct MainScene;");
-//     assert_eq!(mod_file_split[8].trim(), "impl MainScene {");
-//     assert_eq!(mod_file_split[10].trim(), "MainScene {}");
-
-//     assert_eq!(v["modules"][0], "MainScene");
-
-//     assert_eq!(lib_file_split[0], "mod main_scene;");
-//     assert_eq!(
-//         lib_file_split[4].trim(),
-//         "handle.add_class::<main_scene::MainScene>();"
-//     );
-
-//     set_current_dir("../").expect("Unable to change to parent directory");
-
-//     cleanup_test_files();
-
-//     Ok(())
-// }
-
-// #[test]
-// fn create_multiple_modules_should_have_gdns_files_created() -> Result<(), Box<dyn Error>> {
-//     init_test();
-
-//     let mut cmd = Command::cargo_bin("godot-rust-cli")?;
-//     cmd.arg("new")
-//         .arg("platformer_modules")
-//         .arg("platformer")
-//         .arg("--skip-build");
-
-//     cmd.assert().success();
-
-//     set_current_dir("platformer_modules").expect("Unable to change to library directory");
-//     Command::new("cargo")
-//         .arg("run")
-//         .arg("--manifest-path=../../Cargo.toml")
-//         .arg("create")
-//         .arg("Player")
-//         .output()
-//         .expect("Unable to execute cargo run");
-//     Command::new("cargo")
-//         .arg("run")
-//         .arg("--manifest-path=../../Cargo.toml")
-//         .arg("create")
-//         .arg("MainScene")
-//         .output()
-//         .expect("Unable to execute cargo run");
-
-//     let player_file_path = Path::new("src/player.rs");
-//     let main_scene_file_path = Path::new("src/main_scene.rs");
-//     let gdnlib_file_path = Path::new("../platformer/platformer_modules.gdnlib");
-//     let player_ns_file_path = Path::new("../platformer/rust_modules/player.gdns");
-//     let main_scene_ns_file_path = Path::new("../platformer/rust_modules/main_scene.gdns");
-
-//     let config = read_to_string("godot-rust-cli.json").expect("Unable to read config");
-//     let v: Value = serde_json::from_str(&config)?;
-
-//     assert_eq!(player_file_path.exists(), true);
-//     assert_eq!(main_scene_file_path.exists(), true);
-//     assert_eq!(gdnlib_file_path.exists(), true);
-//     assert_eq!(player_ns_file_path.exists(), true);
-//     assert_eq!(main_scene_ns_file_path.exists(), true);
-
-//     assert_eq!(v["modules"][0], "Player");
-//     assert_eq!(v["modules"][1], "MainScene");
-
-//     set_current_dir("../").expect("Unable to change to parent directory");
-
-//     cleanup_test_files();
-
-//     Ok(())
-// }
-
-// #[test]
-// fn create_multiple_modules_should_be_added_to_lib_file() -> Result<(), Box<dyn Error>> {
-//     init_test();
-
-//     let mut cmd = Command::cargo_bin("godot-rust-cli")?;
-//     cmd.arg("new")
-//         .arg("platformer_modules")
-//         .arg("platformer")
-//         .arg("--skip-build");
-
-//     cmd.assert().success();
-
-//     set_current_dir("platformer_modules").expect("Unable to change to library directory");
-//     Command::new("cargo")
-//         .arg("run")
-//         .arg("--manifest-path=../../Cargo.toml")
-//         .arg("create")
-//         .arg("Player")
-//         .output()
-//         .expect("Unable to execute cargo run");
-//     Command::new("cargo")
-//         .arg("run")
-//         .arg("--manifest-path=../../Cargo.toml")
-//         .arg("create")
-//         .arg("MainScene")
-//         .output()
-//         .expect("Unable to execute cargo run");
-
-//     let lib_file = read_to_string("src/lib.rs").expect("Unable to read lib file");
-//     let lib_file_split = lib_file.split("\n").collect::<Vec<&str>>();
-
-//     assert_eq!(lib_file_split[0], "mod main_scene;");
-//     assert_eq!(lib_file_split[1], "mod player;");
-//     assert_eq!(lib_file_split[2], "use gdnative::prelude::*;");
-//     assert_eq!(lib_file_split[3], "");
-//     assert_eq!(lib_file_split[4], "fn init(handle: InitHandle) {");
-//     assert_eq!(
-//         lib_file_split[5].trim(),
-//         "handle.add_class::<player::Player>();"
-//     );
-//     assert_eq!(
-//         lib_file_split[6].trim(),
-//         "handle.add_class::<main_scene::MainScene>();"
-//     );
-//     assert_eq!(lib_file_split[7], "}");
-//     assert_eq!(lib_file_split[8], "");
-//     assert_eq!(lib_file_split[9], "godot_init!(init);");
-//     assert_eq!(lib_file_split[10], "");
-
-//     set_current_dir("../").expect("Unable to change to parent directory");
-
-//     cleanup_test_files();
-
-//     Ok(())
-// }
+use assert_cmd::prelude::*;
+
+use serde_json::{json, Value};
+use std::env::set_current_dir;
+use std::error::Error;
+use std::fs::read_to_string;
+use std::path::Path;
+use std::process::Command;
+
+mod test_utilities;
+use test_utilities::{cleanup_test_files, init_test};
+
+/// Creates a library and then creates a module within the library and
+/// checks that all files are there and their values are what they should be.
+#[test]
+fn create_module_library_structure() -> Result<(), Box<dyn Error>> {
+    init_test();
+
+    // 1. Assert that the new command was successful.
+    let mut cmd_new = Command::new("cargo");
+    cmd_new
+        .arg("run")
+        .arg("--manifest-path=../Cargo.toml")
+        .arg("new")
+        .arg("PlatformerModules")
+        .arg("platformer")
+        .arg("--skip-build");
+    cmd_new.assert().success();
+
+    set_current_dir("platformer_modules")?;
+
+    // 2. Assert that the create command was successful.
+    let mut cmd_create = Command::new("cargo");
+    cmd_create
+        .arg("run")
+        .arg("--manifest-path=../../Cargo.toml")
+        .arg("create")
+        .arg("Player");
+    cmd_create.assert().success();
+
+    // 3. Assert that the module has a mod file.
+    let module_mod_path = Path::new("src/player.rs");
+    assert_eq!(module_mod_path.exists(), true);
+
+    // 4. Assert that the module contents are what we expect.
+    let module_mod_string = read_to_string(module_mod_path)?;
+    let module_mod_split = module_mod_string.split("\r\n").collect::<Vec<&str>>();
+    assert_eq!(module_mod_split[0], "use gdnative::api::Node2D;");
+    assert_eq!(module_mod_split[5], "pub struct Player;");
+    assert_eq!(module_mod_split[8], "impl Player {");
+    assert_eq!(module_mod_split[10].trim(), "Player {}");
+
+    // 4. Assert that the module was added to the lib file.
+    let lib_file_string = read_to_string("src/lib.rs")?;
+    let lib_file_split = lib_file_string.split("\n").collect::<Vec<&str>>();
+    assert_eq!(lib_file_split[0], "mod player;");
+    assert_eq!(
+        lib_file_split[4].trim(),
+        "handle.add_class::<player::Player>();"
+    );
+
+    // 5: Assert that the module was added to the config.
+    let config = read_to_string("godot-rust-cli.json")?;
+    let config_json: Value = serde_json::from_str(&config)?;
+    assert_eq!(config_json["modules"], json!(["Player"]));
+
+    set_current_dir("../")?;
+
+    cleanup_test_files();
+
+    Ok(())
+}
+
+/// Creates a library and then creates a module within the library and
+/// checks the Godot project to make sure all of the files exist and that their
+/// values are what they should be.
+#[test]
+fn create_module_godot_structure() -> Result<(), Box<dyn Error>> {
+    init_test();
+
+    // 1. Assert that the new command was successful.
+    let mut cmd_new = Command::new("cargo");
+    cmd_new
+        .arg("run")
+        .arg("--manifest-path=../Cargo.toml")
+        .arg("new")
+        .arg("PlatformerModules")
+        .arg("platformer")
+        .arg("--skip-build");
+    cmd_new.assert().success();
+
+    set_current_dir("platformer_modules")?;
+
+    // 2. Assert that the create command was successful.
+    let mut cmd_create = Command::new("cargo");
+    cmd_create
+        .arg("run")
+        .arg("--manifest-path=../../Cargo.toml")
+        .arg("create")
+        .arg("Player");
+    cmd_create.assert().success();
+
+    set_current_dir("../")?;
+
+    // 3. Assert that the gdns file for the module was created.
+    let module_gdns_path = Path::new("platformer/rust_modules/player.gdns");
+    assert_eq!(module_gdns_path.exists(), true);
+
+    // 4. Assert that the gnds file has the correct contents.
+    let module_gdns_string = read_to_string(module_gdns_path)?;
+    let module_gdns_split = module_gdns_string.split("\r\n").collect::<Vec<&str>>();
+    assert_eq!(
+        module_gdns_split[2],
+        "[ext_resource path=\"res://platformer_modules.gdnlib\" type=\"GDNativeLibrary\" id=1]"
+    );
+    assert_eq!(module_gdns_split[6], "resource_name = \"Player\"");
+    assert_eq!(module_gdns_split[7], "class_name = \"Player\"");
+
+    cleanup_test_files();
+
+    Ok(())
+}
+
+/// Creates a library and then creates multiple modules within the library and
+/// checks that all files are there and their values are what they should be.
+#[test]
+fn create_multiple_modules_library_structure() -> Result<(), Box<dyn Error>> {
+    init_test();
+
+    // 1. Assert that the new command was successful.
+    let mut cmd_new = Command::new("cargo");
+    cmd_new
+        .arg("run")
+        .arg("--manifest-path=../Cargo.toml")
+        .arg("new")
+        .arg("PlatformerModules")
+        .arg("platformer")
+        .arg("--skip-build");
+    cmd_new.assert().success();
+
+    set_current_dir("platformer_modules")?;
+
+    // 2. Assert that the create commands were successful.
+    let mut cmd_create_player = Command::new("cargo");
+    cmd_create_player
+        .arg("run")
+        .arg("--manifest-path=../../Cargo.toml")
+        .arg("create")
+        .arg("Player");
+    cmd_create_player.assert().success();
+
+    let mut cmd_create_enemy = Command::new("cargo");
+    cmd_create_enemy
+        .arg("run")
+        .arg("--manifest-path=../../Cargo.toml")
+        .arg("create")
+        .arg("Enemy");
+    cmd_create_enemy.assert().success();
+
+    let mut cmd_create_level = Command::new("cargo");
+    cmd_create_level
+        .arg("run")
+        .arg("--manifest-path=../../Cargo.toml")
+        .arg("create")
+        .arg("Level");
+    cmd_create_level.assert().success();
+
+    // 3. Assert that the modules have a mod file.
+    let player_module_mod_path = Path::new("src/player.rs");
+    let enemy_module_mod_path = Path::new("src/enemy.rs");
+    let level_module_mod_path = Path::new("src/level.rs");
+    assert_eq!(player_module_mod_path.exists(), true);
+    assert_eq!(enemy_module_mod_path.exists(), true);
+    assert_eq!(level_module_mod_path.exists(), true);
+
+    // 4. Assert that the modules were added to the lib file.
+    let lib_file_string = read_to_string("src/lib.rs")?;
+    let lib_file_split = lib_file_string.split("\n").collect::<Vec<&str>>();
+    assert_eq!(lib_file_split[0], "mod enemy;");
+    assert_eq!(lib_file_split[1], "mod level;");
+    assert_eq!(lib_file_split[2], "mod player;");
+    assert_eq!(
+        lib_file_split[6].trim(),
+        "handle.add_class::<player::Player>();"
+    );
+    assert_eq!(
+        lib_file_split[7].trim(),
+        "handle.add_class::<level::Level>();"
+    );
+    assert_eq!(
+        lib_file_split[8].trim(),
+        "handle.add_class::<enemy::Enemy>();"
+    );
+
+    // 5: Assert that the modules were added to the config.
+    let config = read_to_string("godot-rust-cli.json")?;
+    let config_json: Value = serde_json::from_str(&config)?;
+    assert_eq!(config_json["modules"], json!(["Player", "Enemy", "Level"]));
+
+    set_current_dir("../")?;
+
+    cleanup_test_files();
+
+    Ok(())
+}
+
+/// Creates a library and then creates multiple modules within the Godot project
+/// and checks that all files are there and their values are what they should be.
+#[test]
+fn create_multiple_modules_godot_structure() -> Result<(), Box<dyn Error>> {
+    init_test();
+
+    // 1. Assert that the new command was successful.
+    let mut cmd_new = Command::new("cargo");
+    cmd_new
+        .arg("run")
+        .arg("--manifest-path=../Cargo.toml")
+        .arg("new")
+        .arg("PlatformerModules")
+        .arg("platformer")
+        .arg("--skip-build");
+    cmd_new.assert().success();
+
+    set_current_dir("platformer_modules")?;
+
+    // 2. Assert that the create commands were successful.
+    let mut cmd_create_player = Command::new("cargo");
+    cmd_create_player
+        .arg("run")
+        .arg("--manifest-path=../../Cargo.toml")
+        .arg("create")
+        .arg("Player");
+    cmd_create_player.assert().success();
+
+    let mut cmd_create_enemy = Command::new("cargo");
+    cmd_create_enemy
+        .arg("run")
+        .arg("--manifest-path=../../Cargo.toml")
+        .arg("create")
+        .arg("Enemy");
+    cmd_create_enemy.assert().success();
+
+    let mut cmd_create_level = Command::new("cargo");
+    cmd_create_level
+        .arg("run")
+        .arg("--manifest-path=../../Cargo.toml")
+        .arg("create")
+        .arg("Level");
+    cmd_create_level.assert().success();
+
+    set_current_dir("../")?;
+
+    // 3. Assert that the gdns files for the modules were created.
+    let player_module_gdns_path = Path::new("platformer/rust_modules/player.gdns");
+    let enemy_module_gdns_path = Path::new("platformer/rust_modules/enemy.gdns");
+    let level_module_gdns_path = Path::new("platformer/rust_modules/level.gdns");
+    assert_eq!(player_module_gdns_path.exists(), true);
+    assert_eq!(enemy_module_gdns_path.exists(), true);
+    assert_eq!(level_module_gdns_path.exists(), true);
+
+    // 4. Assert that the gnds files have the correct contents.
+    let player_module_gdns_string = read_to_string(player_module_gdns_path)?;
+    let player_module_gdns_split = player_module_gdns_string
+        .split("\r\n")
+        .collect::<Vec<&str>>();
+    assert_eq!(
+        player_module_gdns_split[2],
+        "[ext_resource path=\"res://platformer_modules.gdnlib\" type=\"GDNativeLibrary\" id=1]"
+    );
+    assert_eq!(player_module_gdns_split[6], "resource_name = \"Player\"");
+    assert_eq!(player_module_gdns_split[7], "class_name = \"Player\"");
+
+    let enemy_module_gdns_string = read_to_string(enemy_module_gdns_path)?;
+    let enemy_module_gdns_split = enemy_module_gdns_string
+        .split("\r\n")
+        .collect::<Vec<&str>>();
+    assert_eq!(
+        enemy_module_gdns_split[2],
+        "[ext_resource path=\"res://platformer_modules.gdnlib\" type=\"GDNativeLibrary\" id=1]"
+    );
+    assert_eq!(enemy_module_gdns_split[6], "resource_name = \"Enemy\"");
+    assert_eq!(enemy_module_gdns_split[7], "class_name = \"Enemy\"");
+
+    let level_module_gdns_string = read_to_string(level_module_gdns_path)?;
+    let level_module_gdns_split = level_module_gdns_string
+        .split("\r\n")
+        .collect::<Vec<&str>>();
+    assert_eq!(
+        level_module_gdns_split[2],
+        "[ext_resource path=\"res://platformer_modules.gdnlib\" type=\"GDNativeLibrary\" id=1]"
+    );
+    assert_eq!(level_module_gdns_split[6], "resource_name = \"Level\"");
+    assert_eq!(level_module_gdns_split[7], "class_name = \"Level\"");
+
+    cleanup_test_files();
+
+    Ok(())
+}

--- a/tests/command-create.rs
+++ b/tests/command-create.rs
@@ -44,7 +44,7 @@ fn create_module_library_structure() -> Result<(), Box<dyn Error>> {
 
     // 4. Assert that the module contents are what we expect.
     let module_mod_string = read_to_string(module_mod_path)?;
-    let module_mod_split = module_mod_string.split("\r\n").collect::<Vec<&str>>();
+    let module_mod_split = module_mod_string.split("\n").collect::<Vec<&str>>();
     assert_eq!(module_mod_split[0], "use gdnative::api::Node2D;");
     assert_eq!(module_mod_split[5], "pub struct Player;");
     assert_eq!(module_mod_split[8], "impl Player {");
@@ -108,7 +108,7 @@ fn create_module_godot_structure() -> Result<(), Box<dyn Error>> {
 
     // 4. Assert that the gnds file has the correct contents.
     let module_gdns_string = read_to_string(module_gdns_path)?;
-    let module_gdns_split = module_gdns_string.split("\r\n").collect::<Vec<&str>>();
+    let module_gdns_split = module_gdns_string.split("\n").collect::<Vec<&str>>();
     assert_eq!(
         module_gdns_split[2],
         "[ext_resource path=\"res://platformer_modules.gdnlib\" type=\"GDNativeLibrary\" id=1]"
@@ -261,7 +261,7 @@ fn create_multiple_modules_godot_structure() -> Result<(), Box<dyn Error>> {
     // 4. Assert that the gnds files have the correct contents.
     let player_module_gdns_string = read_to_string(player_module_gdns_path)?;
     let player_module_gdns_split = player_module_gdns_string
-        .split("\r\n")
+        .split("\n")
         .collect::<Vec<&str>>();
     assert_eq!(
         player_module_gdns_split[2],
@@ -272,7 +272,7 @@ fn create_multiple_modules_godot_structure() -> Result<(), Box<dyn Error>> {
 
     let enemy_module_gdns_string = read_to_string(enemy_module_gdns_path)?;
     let enemy_module_gdns_split = enemy_module_gdns_string
-        .split("\r\n")
+        .split("\n")
         .collect::<Vec<&str>>();
     assert_eq!(
         enemy_module_gdns_split[2],
@@ -283,7 +283,7 @@ fn create_multiple_modules_godot_structure() -> Result<(), Box<dyn Error>> {
 
     let level_module_gdns_string = read_to_string(level_module_gdns_path)?;
     let level_module_gdns_split = level_module_gdns_string
-        .split("\r\n")
+        .split("\n")
         .collect::<Vec<&str>>();
     assert_eq!(
         level_module_gdns_split[2],

--- a/tests/command-create.rs
+++ b/tests/command-create.rs
@@ -1,363 +1,363 @@
-use assert_cmd::prelude::*;
-
-use serde_json::Value;
-use std::env::set_current_dir;
-use std::error::Error;
-use std::fs::read_to_string;
-use std::path::Path;
-use std::process::Command;
-
-mod test_utilities;
-use test_utilities::{cleanup_test_files, init_test};
-
-#[test]
-fn create_add_module_name_as_pascalcase_to_project_toml_modules() -> Result<(), Box<dyn Error>> {
-    init_test();
-
-    let mut cmd = Command::cargo_bin("godot-rust-cli")?;
-    cmd.arg("new")
-        .arg("platformer_modules")
-        .arg("platformer")
-        .arg("--skip-build");
-
-    cmd.assert().success();
-
-    set_current_dir("platformer_modules").expect("Unable to change to library directory");
-    Command::new("cargo")
-        .arg("run")
-        .arg("--manifest-path=../../Cargo.toml")
-        .arg("create")
-        .arg("Player")
-        .output()
-        .expect("Unable to execute cargo run");
-
-    let config = read_to_string("godot-rust-cli.json").expect("Unable to read config");
-    let v: Value = serde_json::from_str(&config)?;
-
-    assert_eq!(v["godot_project_name"], "platformer");
-    assert_eq!(v["modules"][0], "Player");
-
-    set_current_dir("../").expect("Unable to change to parent directory");
-
-    cleanup_test_files();
-
-    Ok(())
-}
-
-#[test]
-fn create_add_module_mod_and_handle_to_to_lib_file() -> Result<(), Box<dyn Error>> {
-    init_test();
-
-    let mut cmd = Command::cargo_bin("godot-rust-cli")?;
-    cmd.arg("new")
-        .arg("platformer_modules")
-        .arg("platformer")
-        .arg("--skip-build");
-
-    cmd.assert().success();
-
-    set_current_dir("platformer_modules").expect("Unable to change to library directory");
-    Command::new("cargo")
-        .arg("run")
-        .arg("--manifest-path=../../Cargo.toml")
-        .arg("create")
-        .arg("Player")
-        .output()
-        .expect("Unable to execute cargo run");
-
-    let lib_file = read_to_string("src/lib.rs").expect("Unable to read lib file");
-    let lib_file_split = lib_file.split("\n").collect::<Vec<&str>>();
-
-    assert_eq!(lib_file_split[0], "mod player;");
-    assert_eq!(lib_file_split[1], "use gdnative::prelude::*;");
-    assert_eq!(lib_file_split[2], "");
-    assert_eq!(lib_file_split[3], "fn init(handle: InitHandle) {");
-    assert_eq!(
-        lib_file_split[4].trim(),
-        "handle.add_class::<player::Player>();"
-    );
-    assert_eq!(lib_file_split[5], "}");
-    assert_eq!(lib_file_split[6], "");
-    assert_eq!(lib_file_split[7], "godot_init!(init);");
-
-    set_current_dir("../").expect("Unable to change to parent directory");
-
-    cleanup_test_files();
-
-    Ok(())
-}
-
-#[test]
-fn create_module_has_correct_initial_module_file() -> Result<(), Box<dyn Error>> {
-    init_test();
-
-    let mut cmd = Command::cargo_bin("godot-rust-cli")?;
-    cmd.arg("new")
-        .arg("platformer_modules")
-        .arg("platformer")
-        .arg("--skip-build");
-
-    cmd.assert().success();
-
-    set_current_dir("platformer_modules").expect("Unable to change to library directory");
-    Command::new("cargo")
-        .arg("run")
-        .arg("--manifest-path=../../Cargo.toml")
-        .arg("create")
-        .arg("Player")
-        .output()
-        .expect("Unable to execute cargo run");
-
-    let mod_file = read_to_string("src/player.rs").expect("Unable to read module file");
-    let mod_file_split = mod_file.split("\n").collect::<Vec<&str>>();
-
-    assert_eq!(mod_file_split[0].trim(), "use gdnative::api::Node2D;");
-    assert_eq!(mod_file_split[1].trim(), "use gdnative::prelude::*;");
-    assert_eq!(mod_file_split[2].trim(), "");
-    assert_eq!(mod_file_split[3].trim(), "#[inherit(Node2D)]");
-    assert_eq!(mod_file_split[4].trim(), "#[derive(NativeClass)]");
-    assert_eq!(mod_file_split[5].trim(), "pub struct Player;");
-    assert_eq!(mod_file_split[6].trim(), "");
-    assert_eq!(mod_file_split[7].trim(), "#[methods]");
-    assert_eq!(mod_file_split[8].trim(), "impl Player {");
-    assert_eq!(
-        mod_file_split[9].trim(),
-        "fn new(_owner: &Node2D) -> Self {"
-    );
-    assert_eq!(mod_file_split[10].trim(), "Player {}");
-    assert_eq!(mod_file_split[11].trim(), "}");
-    assert_eq!(mod_file_split[12].trim(), "#[export]");
-    assert_eq!(
-        mod_file_split[13].trim(),
-        "fn _ready(&mut self, _owner: &Node2D) {"
-    );
-    assert_eq!(mod_file_split[14].trim(), "godot_print!(\"Hello world!\");");
-    assert_eq!(mod_file_split[15].trim(), "}");
-    assert_eq!(mod_file_split[16].trim(), "");
-    assert_eq!(mod_file_split[17].trim(), "#[export]");
-    assert_eq!(
-        mod_file_split[18].trim(),
-        "fn _process(&mut self, _owner: &Node2D, _delta: f32) {}"
-    );
-
-    set_current_dir("../").expect("Unable to change to parent directory");
-
-    cleanup_test_files();
-
-    Ok(())
-}
-
-#[test]
-fn create_module_gdns_file_in_godot_project_rust_modules_directory() -> Result<(), Box<dyn Error>> {
-    init_test();
-
-    let mut cmd = Command::cargo_bin("godot-rust-cli")?;
-    cmd.arg("new")
-        .arg("platformer_modules")
-        .arg("platformer")
-        .arg("--skip-build");
-
-    cmd.assert().success();
-
-    set_current_dir("platformer_modules").expect("Unable to change to library directory");
-    Command::new("cargo")
-        .arg("run")
-        .arg("--manifest-path=../../Cargo.toml")
-        .arg("create")
-        .arg("Player")
-        .output()
-        .expect("Unable to execute cargo run");
-
-    let gdns_file_contents =
-        read_to_string("../platformer/rust_modules/player.gdns").expect("Unable to read gdns file");
-    let gdns_file_contents_split = gdns_file_contents.split("\n").collect::<Vec<&str>>();
-
-    assert_eq!(
-        gdns_file_contents_split[0].trim(),
-        "[gd_resource type=\"NativeScript\" load_steps=2 format=2]"
-    );
-    assert_eq!(gdns_file_contents_split[1].trim(), "");
-    assert_eq!(
-        gdns_file_contents_split[2].trim(),
-        "[ext_resource path=\"res://platformer_modules.gdnlib\" type=\"GDNativeLibrary\" id=1]"
-    );
-    assert_eq!(gdns_file_contents_split[3].trim(), "");
-    assert_eq!(gdns_file_contents_split[4].trim(), "[resource]");
-    assert_eq!(gdns_file_contents_split[5].trim(), "");
-    assert_eq!(
-        gdns_file_contents_split[6].trim(),
-        "resource_name = \"Player\""
-    );
-    assert_eq!(
-        gdns_file_contents_split[7].trim(),
-        "class_name = \"Player\""
-    );
-    assert_eq!(
-        gdns_file_contents_split[8].trim(),
-        "library = ExtResource( 1 )"
-    );
-
-    set_current_dir("../").expect("Unable to change to parent directory");
-
-    cleanup_test_files();
-
-    Ok(())
-}
-
-#[test]
-fn create_module_name_casing_normalized() -> Result<(), Box<dyn Error>> {
-    init_test();
-
-    let mut cmd = Command::cargo_bin("godot-rust-cli")?;
-    cmd.arg("new")
-        .arg("platformer_modules")
-        .arg("platformer")
-        .arg("--skip-build");
-
-    cmd.assert().success();
-
-    set_current_dir("platformer_modules").expect("Unable to change to library directory");
-    Command::new("cargo")
-        .arg("run")
-        .arg("--manifest-path=../../Cargo.toml")
-        .arg("create")
-        .arg("MainScene")
-        .output()
-        .expect("Unable to execute cargo run");
-
-    let config = read_to_string("godot-rust-cli.json").expect("Unable to read config");
-    let v: Value = serde_json::from_str(&config)?;
-
-    let mod_file = read_to_string("src/main_scene.rs").expect("Unable to read module file");
-    let lib_file = read_to_string("src/lib.rs").expect("Unable to read lib file");
-
-    let mod_file_split = mod_file.split("\n").collect::<Vec<&str>>();
-    let lib_file_split = lib_file.split("\n").collect::<Vec<&str>>();
-
-    assert_eq!(mod_file_split[5].trim(), "pub struct MainScene;");
-    assert_eq!(mod_file_split[8].trim(), "impl MainScene {");
-    assert_eq!(mod_file_split[10].trim(), "MainScene {}");
-
-    assert_eq!(v["modules"][0], "MainScene");
-
-    assert_eq!(lib_file_split[0], "mod main_scene;");
-    assert_eq!(
-        lib_file_split[4].trim(),
-        "handle.add_class::<main_scene::MainScene>();"
-    );
-
-    set_current_dir("../").expect("Unable to change to parent directory");
-
-    cleanup_test_files();
-
-    Ok(())
-}
-
-#[test]
-fn create_multiple_modules_should_have_gdns_files_created() -> Result<(), Box<dyn Error>> {
-    init_test();
-
-    let mut cmd = Command::cargo_bin("godot-rust-cli")?;
-    cmd.arg("new")
-        .arg("platformer_modules")
-        .arg("platformer")
-        .arg("--skip-build");
-
-    cmd.assert().success();
-
-    set_current_dir("platformer_modules").expect("Unable to change to library directory");
-    Command::new("cargo")
-        .arg("run")
-        .arg("--manifest-path=../../Cargo.toml")
-        .arg("create")
-        .arg("Player")
-        .output()
-        .expect("Unable to execute cargo run");
-    Command::new("cargo")
-        .arg("run")
-        .arg("--manifest-path=../../Cargo.toml")
-        .arg("create")
-        .arg("MainScene")
-        .output()
-        .expect("Unable to execute cargo run");
-
-    let player_file_path = Path::new("src/player.rs");
-    let main_scene_file_path = Path::new("src/main_scene.rs");
-    let gdnlib_file_path = Path::new("../platformer/platformer_modules.gdnlib");
-    let player_ns_file_path = Path::new("../platformer/rust_modules/player.gdns");
-    let main_scene_ns_file_path = Path::new("../platformer/rust_modules/main_scene.gdns");
-
-    let config = read_to_string("godot-rust-cli.json").expect("Unable to read config");
-    let v: Value = serde_json::from_str(&config)?;
-
-    assert_eq!(player_file_path.exists(), true);
-    assert_eq!(main_scene_file_path.exists(), true);
-    assert_eq!(gdnlib_file_path.exists(), true);
-    assert_eq!(player_ns_file_path.exists(), true);
-    assert_eq!(main_scene_ns_file_path.exists(), true);
-
-    assert_eq!(v["modules"][0], "Player");
-    assert_eq!(v["modules"][1], "MainScene");
-
-    set_current_dir("../").expect("Unable to change to parent directory");
-
-    cleanup_test_files();
-
-    Ok(())
-}
-
-#[test]
-fn create_multiple_modules_should_be_added_to_lib_file() -> Result<(), Box<dyn Error>> {
-    init_test();
-
-    let mut cmd = Command::cargo_bin("godot-rust-cli")?;
-    cmd.arg("new")
-        .arg("platformer_modules")
-        .arg("platformer")
-        .arg("--skip-build");
-
-    cmd.assert().success();
-
-    set_current_dir("platformer_modules").expect("Unable to change to library directory");
-    Command::new("cargo")
-        .arg("run")
-        .arg("--manifest-path=../../Cargo.toml")
-        .arg("create")
-        .arg("Player")
-        .output()
-        .expect("Unable to execute cargo run");
-    Command::new("cargo")
-        .arg("run")
-        .arg("--manifest-path=../../Cargo.toml")
-        .arg("create")
-        .arg("MainScene")
-        .output()
-        .expect("Unable to execute cargo run");
-
-    let lib_file = read_to_string("src/lib.rs").expect("Unable to read lib file");
-    let lib_file_split = lib_file.split("\n").collect::<Vec<&str>>();
-
-    assert_eq!(lib_file_split[0], "mod main_scene;");
-    assert_eq!(lib_file_split[1], "mod player;");
-    assert_eq!(lib_file_split[2], "use gdnative::prelude::*;");
-    assert_eq!(lib_file_split[3], "");
-    assert_eq!(lib_file_split[4], "fn init(handle: InitHandle) {");
-    assert_eq!(
-        lib_file_split[5].trim(),
-        "handle.add_class::<player::Player>();"
-    );
-    assert_eq!(
-        lib_file_split[6].trim(),
-        "handle.add_class::<main_scene::MainScene>();"
-    );
-    assert_eq!(lib_file_split[7], "}");
-    assert_eq!(lib_file_split[8], "");
-    assert_eq!(lib_file_split[9], "godot_init!(init);");
-    assert_eq!(lib_file_split[10], "");
-
-    set_current_dir("../").expect("Unable to change to parent directory");
-
-    cleanup_test_files();
-
-    Ok(())
-}
+// use assert_cmd::prelude::*;
+
+// use serde_json::Value;
+// use std::env::set_current_dir;
+// use std::error::Error;
+// use std::fs::read_to_string;
+// use std::path::Path;
+// use std::process::Command;
+
+// mod test_utilities;
+// use test_utilities::{cleanup_test_files, init_test};
+
+// #[test]
+// fn create_add_module_name_as_pascalcase_to_project_toml_modules() -> Result<(), Box<dyn Error>> {
+//     init_test();
+
+//     let mut cmd = Command::cargo_bin("godot-rust-cli")?;
+//     cmd.arg("new")
+//         .arg("platformer_modules")
+//         .arg("platformer")
+//         .arg("--skip-build");
+
+//     cmd.assert().success();
+
+//     set_current_dir("platformer_modules").expect("Unable to change to library directory");
+//     Command::new("cargo")
+//         .arg("run")
+//         .arg("--manifest-path=../../Cargo.toml")
+//         .arg("create")
+//         .arg("Player")
+//         .output()
+//         .expect("Unable to execute cargo run");
+
+//     let config = read_to_string("godot-rust-cli.json").expect("Unable to read config");
+//     let v: Value = serde_json::from_str(&config)?;
+
+//     assert_eq!(v["godot_project_name"], "platformer");
+//     assert_eq!(v["modules"][0], "Player");
+
+//     set_current_dir("../").expect("Unable to change to parent directory");
+
+//     cleanup_test_files();
+
+//     Ok(())
+// }
+
+// #[test]
+// fn create_add_module_mod_and_handle_to_to_lib_file() -> Result<(), Box<dyn Error>> {
+//     init_test();
+
+//     let mut cmd = Command::cargo_bin("godot-rust-cli")?;
+//     cmd.arg("new")
+//         .arg("platformer_modules")
+//         .arg("platformer")
+//         .arg("--skip-build");
+
+//     cmd.assert().success();
+
+//     set_current_dir("platformer_modules").expect("Unable to change to library directory");
+//     Command::new("cargo")
+//         .arg("run")
+//         .arg("--manifest-path=../../Cargo.toml")
+//         .arg("create")
+//         .arg("Player")
+//         .output()
+//         .expect("Unable to execute cargo run");
+
+//     let lib_file = read_to_string("src/lib.rs").expect("Unable to read lib file");
+//     let lib_file_split = lib_file.split("\n").collect::<Vec<&str>>();
+
+//     assert_eq!(lib_file_split[0], "mod player;");
+//     assert_eq!(lib_file_split[1], "use gdnative::prelude::*;");
+//     assert_eq!(lib_file_split[2], "");
+//     assert_eq!(lib_file_split[3], "fn init(handle: InitHandle) {");
+//     assert_eq!(
+//         lib_file_split[4].trim(),
+//         "handle.add_class::<player::Player>();"
+//     );
+//     assert_eq!(lib_file_split[5], "}");
+//     assert_eq!(lib_file_split[6], "");
+//     assert_eq!(lib_file_split[7], "godot_init!(init);");
+
+//     set_current_dir("../").expect("Unable to change to parent directory");
+
+//     cleanup_test_files();
+
+//     Ok(())
+// }
+
+// #[test]
+// fn create_module_has_correct_initial_module_file() -> Result<(), Box<dyn Error>> {
+//     init_test();
+
+//     let mut cmd = Command::cargo_bin("godot-rust-cli")?;
+//     cmd.arg("new")
+//         .arg("platformer_modules")
+//         .arg("platformer")
+//         .arg("--skip-build");
+
+//     cmd.assert().success();
+
+//     set_current_dir("platformer_modules").expect("Unable to change to library directory");
+//     Command::new("cargo")
+//         .arg("run")
+//         .arg("--manifest-path=../../Cargo.toml")
+//         .arg("create")
+//         .arg("Player")
+//         .output()
+//         .expect("Unable to execute cargo run");
+
+//     let mod_file = read_to_string("src/player.rs").expect("Unable to read module file");
+//     let mod_file_split = mod_file.split("\n").collect::<Vec<&str>>();
+
+//     assert_eq!(mod_file_split[0].trim(), "use gdnative::api::Node2D;");
+//     assert_eq!(mod_file_split[1].trim(), "use gdnative::prelude::*;");
+//     assert_eq!(mod_file_split[2].trim(), "");
+//     assert_eq!(mod_file_split[3].trim(), "#[inherit(Node2D)]");
+//     assert_eq!(mod_file_split[4].trim(), "#[derive(NativeClass)]");
+//     assert_eq!(mod_file_split[5].trim(), "pub struct Player;");
+//     assert_eq!(mod_file_split[6].trim(), "");
+//     assert_eq!(mod_file_split[7].trim(), "#[methods]");
+//     assert_eq!(mod_file_split[8].trim(), "impl Player {");
+//     assert_eq!(
+//         mod_file_split[9].trim(),
+//         "fn new(_owner: &Node2D) -> Self {"
+//     );
+//     assert_eq!(mod_file_split[10].trim(), "Player {}");
+//     assert_eq!(mod_file_split[11].trim(), "}");
+//     assert_eq!(mod_file_split[12].trim(), "#[export]");
+//     assert_eq!(
+//         mod_file_split[13].trim(),
+//         "fn _ready(&mut self, _owner: &Node2D) {"
+//     );
+//     assert_eq!(mod_file_split[14].trim(), "godot_print!(\"Hello world!\");");
+//     assert_eq!(mod_file_split[15].trim(), "}");
+//     assert_eq!(mod_file_split[16].trim(), "");
+//     assert_eq!(mod_file_split[17].trim(), "#[export]");
+//     assert_eq!(
+//         mod_file_split[18].trim(),
+//         "fn _process(&mut self, _owner: &Node2D, _delta: f32) {}"
+//     );
+
+//     set_current_dir("../").expect("Unable to change to parent directory");
+
+//     cleanup_test_files();
+
+//     Ok(())
+// }
+
+// #[test]
+// fn create_module_gdns_file_in_godot_project_rust_modules_directory() -> Result<(), Box<dyn Error>> {
+//     init_test();
+
+//     let mut cmd = Command::cargo_bin("godot-rust-cli")?;
+//     cmd.arg("new")
+//         .arg("platformer_modules")
+//         .arg("platformer")
+//         .arg("--skip-build");
+
+//     cmd.assert().success();
+
+//     set_current_dir("platformer_modules").expect("Unable to change to library directory");
+//     Command::new("cargo")
+//         .arg("run")
+//         .arg("--manifest-path=../../Cargo.toml")
+//         .arg("create")
+//         .arg("Player")
+//         .output()
+//         .expect("Unable to execute cargo run");
+
+//     let gdns_file_contents =
+//         read_to_string("../platformer/rust_modules/player.gdns").expect("Unable to read gdns file");
+//     let gdns_file_contents_split = gdns_file_contents.split("\n").collect::<Vec<&str>>();
+
+//     assert_eq!(
+//         gdns_file_contents_split[0].trim(),
+//         "[gd_resource type=\"NativeScript\" load_steps=2 format=2]"
+//     );
+//     assert_eq!(gdns_file_contents_split[1].trim(), "");
+//     assert_eq!(
+//         gdns_file_contents_split[2].trim(),
+//         "[ext_resource path=\"res://platformer_modules.gdnlib\" type=\"GDNativeLibrary\" id=1]"
+//     );
+//     assert_eq!(gdns_file_contents_split[3].trim(), "");
+//     assert_eq!(gdns_file_contents_split[4].trim(), "[resource]");
+//     assert_eq!(gdns_file_contents_split[5].trim(), "");
+//     assert_eq!(
+//         gdns_file_contents_split[6].trim(),
+//         "resource_name = \"Player\""
+//     );
+//     assert_eq!(
+//         gdns_file_contents_split[7].trim(),
+//         "class_name = \"Player\""
+//     );
+//     assert_eq!(
+//         gdns_file_contents_split[8].trim(),
+//         "library = ExtResource( 1 )"
+//     );
+
+//     set_current_dir("../").expect("Unable to change to parent directory");
+
+//     cleanup_test_files();
+
+//     Ok(())
+// }
+
+// #[test]
+// fn create_module_name_casing_normalized() -> Result<(), Box<dyn Error>> {
+//     init_test();
+
+//     let mut cmd = Command::cargo_bin("godot-rust-cli")?;
+//     cmd.arg("new")
+//         .arg("platformer_modules")
+//         .arg("platformer")
+//         .arg("--skip-build");
+
+//     cmd.assert().success();
+
+//     set_current_dir("platformer_modules").expect("Unable to change to library directory");
+//     Command::new("cargo")
+//         .arg("run")
+//         .arg("--manifest-path=../../Cargo.toml")
+//         .arg("create")
+//         .arg("MainScene")
+//         .output()
+//         .expect("Unable to execute cargo run");
+
+//     let config = read_to_string("godot-rust-cli.json").expect("Unable to read config");
+//     let v: Value = serde_json::from_str(&config)?;
+
+//     let mod_file = read_to_string("src/main_scene.rs").expect("Unable to read module file");
+//     let lib_file = read_to_string("src/lib.rs").expect("Unable to read lib file");
+
+//     let mod_file_split = mod_file.split("\n").collect::<Vec<&str>>();
+//     let lib_file_split = lib_file.split("\n").collect::<Vec<&str>>();
+
+//     assert_eq!(mod_file_split[5].trim(), "pub struct MainScene;");
+//     assert_eq!(mod_file_split[8].trim(), "impl MainScene {");
+//     assert_eq!(mod_file_split[10].trim(), "MainScene {}");
+
+//     assert_eq!(v["modules"][0], "MainScene");
+
+//     assert_eq!(lib_file_split[0], "mod main_scene;");
+//     assert_eq!(
+//         lib_file_split[4].trim(),
+//         "handle.add_class::<main_scene::MainScene>();"
+//     );
+
+//     set_current_dir("../").expect("Unable to change to parent directory");
+
+//     cleanup_test_files();
+
+//     Ok(())
+// }
+
+// #[test]
+// fn create_multiple_modules_should_have_gdns_files_created() -> Result<(), Box<dyn Error>> {
+//     init_test();
+
+//     let mut cmd = Command::cargo_bin("godot-rust-cli")?;
+//     cmd.arg("new")
+//         .arg("platformer_modules")
+//         .arg("platformer")
+//         .arg("--skip-build");
+
+//     cmd.assert().success();
+
+//     set_current_dir("platformer_modules").expect("Unable to change to library directory");
+//     Command::new("cargo")
+//         .arg("run")
+//         .arg("--manifest-path=../../Cargo.toml")
+//         .arg("create")
+//         .arg("Player")
+//         .output()
+//         .expect("Unable to execute cargo run");
+//     Command::new("cargo")
+//         .arg("run")
+//         .arg("--manifest-path=../../Cargo.toml")
+//         .arg("create")
+//         .arg("MainScene")
+//         .output()
+//         .expect("Unable to execute cargo run");
+
+//     let player_file_path = Path::new("src/player.rs");
+//     let main_scene_file_path = Path::new("src/main_scene.rs");
+//     let gdnlib_file_path = Path::new("../platformer/platformer_modules.gdnlib");
+//     let player_ns_file_path = Path::new("../platformer/rust_modules/player.gdns");
+//     let main_scene_ns_file_path = Path::new("../platformer/rust_modules/main_scene.gdns");
+
+//     let config = read_to_string("godot-rust-cli.json").expect("Unable to read config");
+//     let v: Value = serde_json::from_str(&config)?;
+
+//     assert_eq!(player_file_path.exists(), true);
+//     assert_eq!(main_scene_file_path.exists(), true);
+//     assert_eq!(gdnlib_file_path.exists(), true);
+//     assert_eq!(player_ns_file_path.exists(), true);
+//     assert_eq!(main_scene_ns_file_path.exists(), true);
+
+//     assert_eq!(v["modules"][0], "Player");
+//     assert_eq!(v["modules"][1], "MainScene");
+
+//     set_current_dir("../").expect("Unable to change to parent directory");
+
+//     cleanup_test_files();
+
+//     Ok(())
+// }
+
+// #[test]
+// fn create_multiple_modules_should_be_added_to_lib_file() -> Result<(), Box<dyn Error>> {
+//     init_test();
+
+//     let mut cmd = Command::cargo_bin("godot-rust-cli")?;
+//     cmd.arg("new")
+//         .arg("platformer_modules")
+//         .arg("platformer")
+//         .arg("--skip-build");
+
+//     cmd.assert().success();
+
+//     set_current_dir("platformer_modules").expect("Unable to change to library directory");
+//     Command::new("cargo")
+//         .arg("run")
+//         .arg("--manifest-path=../../Cargo.toml")
+//         .arg("create")
+//         .arg("Player")
+//         .output()
+//         .expect("Unable to execute cargo run");
+//     Command::new("cargo")
+//         .arg("run")
+//         .arg("--manifest-path=../../Cargo.toml")
+//         .arg("create")
+//         .arg("MainScene")
+//         .output()
+//         .expect("Unable to execute cargo run");
+
+//     let lib_file = read_to_string("src/lib.rs").expect("Unable to read lib file");
+//     let lib_file_split = lib_file.split("\n").collect::<Vec<&str>>();
+
+//     assert_eq!(lib_file_split[0], "mod main_scene;");
+//     assert_eq!(lib_file_split[1], "mod player;");
+//     assert_eq!(lib_file_split[2], "use gdnative::prelude::*;");
+//     assert_eq!(lib_file_split[3], "");
+//     assert_eq!(lib_file_split[4], "fn init(handle: InitHandle) {");
+//     assert_eq!(
+//         lib_file_split[5].trim(),
+//         "handle.add_class::<player::Player>();"
+//     );
+//     assert_eq!(
+//         lib_file_split[6].trim(),
+//         "handle.add_class::<main_scene::MainScene>();"
+//     );
+//     assert_eq!(lib_file_split[7], "}");
+//     assert_eq!(lib_file_split[8], "");
+//     assert_eq!(lib_file_split[9], "godot_init!(init);");
+//     assert_eq!(lib_file_split[10], "");
+
+//     set_current_dir("../").expect("Unable to change to parent directory");
+
+//     cleanup_test_files();
+
+//     Ok(())
+// }

--- a/tests/command-create.rs
+++ b/tests/command-create.rs
@@ -44,7 +44,10 @@ fn create_module_library_structure() -> Result<(), Box<dyn Error>> {
 
     // 4. Assert that the module contents are what we expect.
     let module_mod_string = read_to_string(module_mod_path)?;
-    let module_mod_split = module_mod_string.split("\n").collect::<Vec<&str>>();
+    let module_mod_split = module_mod_string
+        .split("\n")
+        .map(|x| x.replace("\r", ""))
+        .collect::<Vec<String>>();
     assert_eq!(module_mod_split[0], "use gdnative::api::Node2D;");
     assert_eq!(module_mod_split[5], "pub struct Player;");
     assert_eq!(module_mod_split[8], "impl Player {");
@@ -52,7 +55,10 @@ fn create_module_library_structure() -> Result<(), Box<dyn Error>> {
 
     // 4. Assert that the module was added to the lib file.
     let lib_file_string = read_to_string("src/lib.rs")?;
-    let lib_file_split = lib_file_string.split("\n").collect::<Vec<&str>>();
+    let lib_file_split = lib_file_string
+        .split("\n")
+        .map(|x| x.replace("\r", ""))
+        .collect::<Vec<String>>();
     assert_eq!(lib_file_split[0], "mod player;");
     assert_eq!(
         lib_file_split[4].trim(),
@@ -108,7 +114,10 @@ fn create_module_godot_structure() -> Result<(), Box<dyn Error>> {
 
     // 4. Assert that the gnds file has the correct contents.
     let module_gdns_string = read_to_string(module_gdns_path)?;
-    let module_gdns_split = module_gdns_string.split("\n").collect::<Vec<&str>>();
+    let module_gdns_split = module_gdns_string
+        .split("\n")
+        .map(|x| x.replace("\r", ""))
+        .collect::<Vec<String>>();
     assert_eq!(
         module_gdns_split[2],
         "[ext_resource path=\"res://platformer_modules.gdnlib\" type=\"GDNativeLibrary\" id=1]"
@@ -175,7 +184,10 @@ fn create_multiple_modules_library_structure() -> Result<(), Box<dyn Error>> {
 
     // 4. Assert that the modules were added to the lib file.
     let lib_file_string = read_to_string("src/lib.rs")?;
-    let lib_file_split = lib_file_string.split("\n").collect::<Vec<&str>>();
+    let lib_file_split = lib_file_string
+        .split("\n")
+        .map(|x| x.replace("\r", ""))
+        .collect::<Vec<String>>();
     assert_eq!(lib_file_split[0], "mod enemy;");
     assert_eq!(lib_file_split[1], "mod level;");
     assert_eq!(lib_file_split[2], "mod player;");
@@ -262,7 +274,8 @@ fn create_multiple_modules_godot_structure() -> Result<(), Box<dyn Error>> {
     let player_module_gdns_string = read_to_string(player_module_gdns_path)?;
     let player_module_gdns_split = player_module_gdns_string
         .split("\n")
-        .collect::<Vec<&str>>();
+        .map(|x| x.replace("\r", ""))
+        .collect::<Vec<String>>();
     assert_eq!(
         player_module_gdns_split[2],
         "[ext_resource path=\"res://platformer_modules.gdnlib\" type=\"GDNativeLibrary\" id=1]"
@@ -273,7 +286,8 @@ fn create_multiple_modules_godot_structure() -> Result<(), Box<dyn Error>> {
     let enemy_module_gdns_string = read_to_string(enemy_module_gdns_path)?;
     let enemy_module_gdns_split = enemy_module_gdns_string
         .split("\n")
-        .collect::<Vec<&str>>();
+        .map(|x| x.replace("\r", ""))
+        .collect::<Vec<String>>();
     assert_eq!(
         enemy_module_gdns_split[2],
         "[ext_resource path=\"res://platformer_modules.gdnlib\" type=\"GDNativeLibrary\" id=1]"
@@ -284,7 +298,8 @@ fn create_multiple_modules_godot_structure() -> Result<(), Box<dyn Error>> {
     let level_module_gdns_string = read_to_string(level_module_gdns_path)?;
     let level_module_gdns_split = level_module_gdns_string
         .split("\n")
-        .collect::<Vec<&str>>();
+        .map(|x| x.replace("\r", ""))
+        .collect::<Vec<String>>();
     assert_eq!(
         level_module_gdns_split[2],
         "[ext_resource path=\"res://platformer_modules.gdnlib\" type=\"GDNativeLibrary\" id=1]"

--- a/tests/command-destroy.rs
+++ b/tests/command-destroy.rs
@@ -1,262 +1,398 @@
-// use assert_cmd::prelude::*;
+use assert_cmd::prelude::*;
 
-// use serde_json::{json, Value};
-// use std::env::set_current_dir;
-// use std::error::Error;
-// use std::fs::read_to_string;
-// use std::path::Path;
-// use std::process::Command;
+use serde_json::{json, Value};
+use std::env::set_current_dir;
+use std::error::Error;
+use std::fs::read_to_string;
+use std::path::Path;
+use std::process::Command;
 
-// mod test_utilities;
-// use test_utilities::{cleanup_test_files, init_test};
+mod test_utilities;
+use test_utilities::{cleanup_test_files, init_test};
 
-// #[test]
-// fn destroy_remove_module_from_library_lib_file_and_godot_project_rust_modules(
-// ) -> Result<(), Box<dyn Error>> {
-//     init_test();
+/// Creates a library and a module and then destroys it and checks to make sure
+/// the library structure is correct.
+#[test]
+fn destroy_module_library_structure() -> Result<(), Box<dyn Error>> {
+    init_test();
 
-//     let mut cmd = Command::cargo_bin("godot-rust-cli")?;
-//     cmd.arg("new")
-//         .arg("platformer_modules")
-//         .arg("platformer")
-//         .arg("--skip-build");
+    // 1. Assert that the new command was successful.
+    let mut cmd_new = Command::new("cargo");
+    cmd_new
+        .arg("run")
+        .arg("--manifest-path=../Cargo.toml")
+        .arg("new")
+        .arg("PlatformerModules")
+        .arg("platformer")
+        .arg("--skip-build");
+    cmd_new.assert().success();
 
-//     cmd.assert().success();
+    set_current_dir("platformer_modules")?;
 
-//     set_current_dir("platformer_modules").expect("Unable to change to library directory");
-//     Command::new("cargo")
-//         .arg("run")
-//         .arg("--manifest-path=../../Cargo.toml")
-//         .arg("create")
-//         .arg("Player")
-//         .output()
-//         .expect("Unable to execute cargo run");
-//     Command::new("cargo")
-//         .arg("run")
-//         .arg("--manifest-path=../../Cargo.toml")
-//         .arg("destroy")
-//         .arg("Player")
-//         .output()
-//         .expect("Unable to execute cargo run");
+    // 2. Assert that the create command was successful.
+    let mut cmd_create = Command::new("cargo");
+    cmd_create
+        .arg("run")
+        .arg("--manifest-path=../../Cargo.toml")
+        .arg("create")
+        .arg("Player");
+    cmd_create.assert().success();
 
-//     let lib_file = read_to_string("src/lib.rs").expect("Unable to read lib file");
-//     let lib_file_split = lib_file.split("\n").collect::<Vec<&str>>();
+    // 3. Assert that the destroy command was successful.
+    let mut cmd_destroy = Command::new("cargo");
+    cmd_destroy
+        .arg("run")
+        .arg("--manifest-path=../../Cargo.toml")
+        .arg("destroy")
+        .arg("Player");
+    cmd_destroy.assert().success();
 
-//     let config = read_to_string("godot-rust-cli.json").expect("Unable to read config");
-//     let v: Value = serde_json::from_str(&config)?;
+    // 4. Assert that the module no longer has a mod file.
+    let module_mod_path = Path::new("src/player.rs");
+    assert_eq!(module_mod_path.exists(), false);
 
-//     let mod_file_path = Path::new("src/player.rs");
+    // 5. Assert that the module was removed from the lib file.
+    let lib_file_string = read_to_string("src/lib.rs")?;
+    let lib_file_split = lib_file_string.split("\n").collect::<Vec<&str>>();
+    assert_eq!(lib_file_split[0], "use gdnative::prelude::*;");
+    assert_eq!(lib_file_split[1], "");
+    assert_eq!(lib_file_split[2], "fn init(handle: InitHandle) {}");
+    assert_eq!(lib_file_split[3], "");
+    assert_eq!(lib_file_split[4], "godot_init!(init);");
 
-//     let player_gdns_file = Path::new("../platformer/rust_modules/player.gdns");
+    // 6. Assert that the module was removed from the config.
+    let config = read_to_string("godot-rust-cli.json")?;
+    let config_json: Value = serde_json::from_str(&config)?;
+    assert_eq!(config_json["modules"], json!([]));
 
-//     assert_eq!(lib_file_split[0], "use gdnative::prelude::*;");
-//     assert_eq!(lib_file_split[1], "");
-//     assert_eq!(lib_file_split[2], "fn init(handle: InitHandle) {}");
-//     assert_eq!(lib_file_split[3], "");
-//     assert_eq!(lib_file_split[4], "godot_init!(init);");
-//     assert_eq!(v["modules"], json!([]));
+    set_current_dir("../")?;
 
-//     assert_eq!(mod_file_path.exists(), false);
-//     assert_eq!(player_gdns_file.exists(), false);
+    cleanup_test_files();
 
-//     set_current_dir("../").expect("Unable to change to parent directory");
+    Ok(())
+}
 
-//     cleanup_test_files();
+/// Creates a library and a module and then destroys it and checks to make sure
+/// the Godot project structure is correct.
+#[test]
+fn destroy_module_godot_structure() -> Result<(), Box<dyn Error>> {
+    init_test();
 
-//     Ok(())
-// }
+    // 1. Assert that the new command was successful.
+    let mut cmd_new = Command::new("cargo");
+    cmd_new
+        .arg("run")
+        .arg("--manifest-path=../Cargo.toml")
+        .arg("new")
+        .arg("PlatformerModules")
+        .arg("platformer")
+        .arg("--skip-build");
+    cmd_new.assert().success();
 
-// #[test]
-// fn destroy_create_five_modules_remove_two_modules() -> Result<(), Box<dyn Error>> {
-//     init_test();
+    set_current_dir("platformer_modules")?;
 
-//     let mut cmd = Command::cargo_bin("godot-rust-cli")?;
-//     cmd.arg("new")
-//         .arg("platformer_modules")
-//         .arg("platformer")
-//         .arg("--skip-build");
+    // 2. Assert that the create command was successful.
+    let mut cmd_create = Command::new("cargo");
+    cmd_create
+        .arg("run")
+        .arg("--manifest-path=../../Cargo.toml")
+        .arg("create")
+        .arg("Player");
+    cmd_create.assert().success();
 
-//     cmd.assert().success();
+    // 3. Assert that the destroy command was successful.
+    let mut cmd_destroy = Command::new("cargo");
+    cmd_destroy
+        .arg("run")
+        .arg("--manifest-path=../../Cargo.toml")
+        .arg("destroy")
+        .arg("Player");
+    cmd_destroy.assert().success();
 
-//     set_current_dir("platformer_modules").expect("Unable to change to library directory");
-//     Command::new("cargo")
-//         .arg("run")
-//         .arg("--manifest-path=../../Cargo.toml")
-//         .arg("create")
-//         .arg("Player")
-//         .output()
-//         .expect("Unable to execute cargo run");
-//     Command::new("cargo")
-//         .arg("run")
-//         .arg("--manifest-path=../../Cargo.toml")
-//         .arg("create")
-//         .arg("MainScene")
-//         .output()
-//         .expect("Unable to execute cargo run");
-//     Command::new("cargo")
-//         .arg("run")
-//         .arg("--manifest-path=../../Cargo.toml")
-//         .arg("create")
-//         .arg("Ship")
-//         .output()
-//         .expect("Unable to execute cargo run");
-//     Command::new("cargo")
-//         .arg("run")
-//         .arg("--manifest-path=../../Cargo.toml")
-//         .arg("create")
-//         .arg("Vehicle")
-//         .output()
-//         .expect("Unable to execute cargo run");
-//     Command::new("cargo")
-//         .arg("run")
-//         .arg("--manifest-path=../../Cargo.toml")
-//         .arg("create")
-//         .arg("Enemy")
-//         .output()
-//         .expect("Unable to execute cargo run");
-//     Command::new("cargo")
-//         .arg("run")
-//         .arg("--manifest-path=../../Cargo.toml")
-//         .arg("destroy")
-//         .arg("Ship")
-//         .output()
-//         .expect("Unable to execute cargo run");
-//     Command::new("cargo")
-//         .arg("run")
-//         .arg("--manifest-path=../../Cargo.toml")
-//         .arg("destroy")
-//         .arg("Enemy")
-//         .output()
-//         .expect("Unable to execute cargo run");
+    set_current_dir("../")?;
 
-//     let lib_file = read_to_string("src/lib.rs").expect("Unable to read lib file");
-//     let lib_file_split = lib_file.split("\n").collect::<Vec<&str>>();
+    // 4. Assert that the module no longer has a gdns file.
+    let module_gdns_path = Path::new("platformer/rust_modules/player.gdns");
+    assert_eq!(module_gdns_path.exists(), false);
 
-//     let config = read_to_string("godot-rust-cli.json").expect("Unable to read config");
-//     let v: Value = serde_json::from_str(&config)?;
+    Ok(())
+}
 
-//     let player_mod_file_path = Path::new("src/player.rs");
-//     let main_scene_mod_file_path = Path::new("src/main_scene.rs");
-//     let ship_mod_file_path = Path::new("src/ship.rs");
-//     let vehicle_mod_file_path = Path::new("src/vehicle.rs");
-//     let enemy_mod_file_path = Path::new("src/enemy.rs");
+/// Creates a library and 5 modules and then destroys 2 of them and checks to
+/// make sure the library structure is correct.
+#[test]
+fn destroy_modules_library_structure() -> Result<(), Box<dyn Error>> {
+    init_test();
 
-//     let player_gdns_file = Path::new("../platformer/rust_modules/player.gdns");
-//     let main_scene_gdns_file = Path::new("../platformer/rust_modules/main_scene.gdns");
-//     let ship_gdns_file = Path::new("../platformer/rust_modules/ship.gdns");
-//     let vehicle_gdns_file = Path::new("../platformer/rust_modules/vehicle.gdns");
-//     let enemy_gdns_file = Path::new("../platformer/rust_modules/enemy.gdns");
+    // 1. Assert that the new command was successful.
+    let mut cmd_new = Command::new("cargo");
+    cmd_new
+        .arg("run")
+        .arg("--manifest-path=../Cargo.toml")
+        .arg("new")
+        .arg("PlatformerModules")
+        .arg("platformer")
+        .arg("--skip-build");
+    cmd_new.assert().success();
 
-//     assert_eq!(lib_file_split[0], "mod main_scene;");
-//     assert_eq!(lib_file_split[1], "mod player;");
-//     assert_eq!(lib_file_split[2], "mod vehicle;");
-//     assert_eq!(lib_file_split[3], "use gdnative::prelude::*;");
-//     assert_eq!(lib_file_split[4], "");
-//     assert_eq!(lib_file_split[5], "fn init(handle: InitHandle) {");
-//     assert_eq!(
-//         lib_file_split[6].trim(),
-//         "handle.add_class::<player::Player>();"
-//     );
-//     assert_eq!(
-//         lib_file_split[7].trim(),
-//         "handle.add_class::<vehicle::Vehicle>();"
-//     );
-//     assert_eq!(
-//         lib_file_split[8].trim(),
-//         "handle.add_class::<main_scene::MainScene>();"
-//     );
-//     assert_eq!(lib_file_split[9], "}");
-//     assert_eq!(lib_file_split[10], "");
-//     assert_eq!(lib_file_split[11], "godot_init!(init);");
+    set_current_dir("platformer_modules")?;
 
-//     assert_eq!(v["modules"][0], "Player");
-//     assert_eq!(v["modules"][1], "MainScene");
-//     assert_eq!(v["modules"][2], "Vehicle");
+    // 2. Assert that the create commands were successful.
+    let mut cmd_create_player = Command::new("cargo");
+    cmd_create_player
+        .arg("run")
+        .arg("--manifest-path=../../Cargo.toml")
+        .arg("create")
+        .arg("Player");
+    cmd_create_player.assert().success();
+    let mut cmd_create_enemy = Command::new("cargo");
+    cmd_create_enemy
+        .arg("run")
+        .arg("--manifest-path=../../Cargo.toml")
+        .arg("create")
+        .arg("Enemy");
+    cmd_create_enemy.assert().success();
+    let mut cmd_create_level = Command::new("cargo");
+    cmd_create_level
+        .arg("run")
+        .arg("--manifest-path=../../Cargo.toml")
+        .arg("create")
+        .arg("Level");
+    cmd_create_level.assert().success();
+    let mut cmd_create_environment = Command::new("cargo");
+    cmd_create_environment
+        .arg("run")
+        .arg("--manifest-path=../../Cargo.toml")
+        .arg("create")
+        .arg("Environment");
+    cmd_create_environment.assert().success();
+    let mut cmd_create_space = Command::new("cargo");
+    cmd_create_space
+        .arg("run")
+        .arg("--manifest-path=../../Cargo.toml")
+        .arg("create")
+        .arg("Space");
+    cmd_create_space.assert().success();
 
-//     assert_eq!(player_mod_file_path.exists(), true);
-//     assert_eq!(main_scene_mod_file_path.exists(), true);
-//     assert_eq!(vehicle_mod_file_path.exists(), true);
-//     assert_eq!(enemy_mod_file_path.exists(), false);
-//     assert_eq!(ship_mod_file_path.exists(), false);
+    // 3. Assert that the destroy commands were successful.
+    let mut cmd_destroy_enemy = Command::new("cargo");
+    cmd_destroy_enemy
+        .arg("run")
+        .arg("--manifest-path=../../Cargo.toml")
+        .arg("destroy")
+        .arg("Enemy");
+    cmd_destroy_enemy.assert().success();
+    let mut cmd_destroy_space = Command::new("cargo");
+    cmd_destroy_space
+        .arg("run")
+        .arg("--manifest-path=../../Cargo.toml")
+        .arg("destroy")
+        .arg("Space");
+    cmd_destroy_space.assert().success();
 
-//     assert_eq!(player_gdns_file.exists(), true);
-//     assert_eq!(main_scene_gdns_file.exists(), true);
-//     assert_eq!(vehicle_gdns_file.exists(), true);
-//     assert_eq!(enemy_gdns_file.exists(), false);
-//     assert_eq!(ship_gdns_file.exists(), false);
+    // 4. Assert that the modules that weren't destroyed have mod files.
+    let player_module_mod_path = Path::new("src/player.rs");
+    let level_module_mod_path = Path::new("src/level.rs");
+    let environment_module_mod_path = Path::new("src/environment.rs");
+    assert_eq!(player_module_mod_path.exists(), true);
+    assert_eq!(level_module_mod_path.exists(), true);
+    assert_eq!(environment_module_mod_path.exists(), true);
 
-//     set_current_dir("../").expect("Unable to change to parent directory");
+    // 5. Assert that the modules that were deleted no longer have mod files.
+    let enemy_module_mod_path = Path::new("src/enemy.rs");
+    let space_module_mod_path = Path::new("src/space.rs");
+    assert_eq!(enemy_module_mod_path.exists(), false);
+    assert_eq!(space_module_mod_path.exists(), false);
 
-//     cleanup_test_files();
+    // 6. Assert that the modules were removed from the lib file.
+    let lib_file_string = read_to_string("src/lib.rs")?;
+    let lib_file_split = lib_file_string.split("\n").collect::<Vec<&str>>();
+    assert_eq!(lib_file_split[0], "mod environment;");
+    assert_eq!(lib_file_split[1], "mod level;");
+    assert_eq!(lib_file_split[2], "mod player;");
+    assert_eq!(lib_file_split[3], "use gdnative::prelude::*;");
+    assert_eq!(lib_file_split[4], "");
+    assert_eq!(lib_file_split[5], "fn init(handle: InitHandle) {");
+    assert_eq!(
+        lib_file_split[6].trim(),
+        "handle.add_class::<player::Player>();"
+    );
+    assert_eq!(
+        lib_file_split[7].trim(),
+        "handle.add_class::<environment::Environment>();"
+    );
+    assert_eq!(
+        lib_file_split[8].trim(),
+        "handle.add_class::<level::Level>();"
+    );
+    assert_eq!(lib_file_split[9], "}");
+    assert_eq!(lib_file_split[10], "");
+    assert_eq!(lib_file_split[11], "godot_init!(init);");
 
-//     Ok(())
-// }
+    // 7. Assert that the modules were removed from the config.
+    let config = read_to_string("godot-rust-cli.json")?;
+    let config_json: Value = serde_json::from_str(&config)?;
+    assert_eq!(
+        config_json["modules"],
+        json!(["Player", "Level", "Environment"])
+    );
 
-// #[test]
-// fn destroy_remove_moved_module() -> Result<(), Box<dyn Error>> {
-//     init_test();
+    set_current_dir("../")?;
 
-//     let mut cmd = Command::cargo_bin("godot-rust-cli")?;
-//     cmd.arg("new")
-//         .arg("platformer_modules")
-//         .arg("platformer")
-//         .arg("--skip-build");
+    cleanup_test_files();
 
-//     cmd.assert().success();
+    Ok(())
+}
 
-//     set_current_dir("platformer_modules").expect("Unable to change to library directory");
-//     Command::new("cargo")
-//         .arg("run")
-//         .arg("--manifest-path=../../Cargo.toml")
-//         .arg("create")
-//         .arg("Player")
-//         .output()
-//         .expect("Unable to execute cargo run");
+/// Creates a library and 5 modules and then destroys 2 of them and checks to
+/// make sure the Godot project structure is correct.
+#[test]
+fn destroy_modules_godot_structure() -> Result<(), Box<dyn Error>> {
+    init_test();
 
-//     Command::new("mkdir")
-//         .arg("../platformer/player")
-//         .output()
-//         .expect("Unable to create player dir");
+    // 1. Assert that the new command was successful.
+    let mut cmd_new = Command::new("cargo");
+    cmd_new
+        .arg("run")
+        .arg("--manifest-path=../Cargo.toml")
+        .arg("new")
+        .arg("PlatformerModules")
+        .arg("platformer")
+        .arg("--skip-build");
+    cmd_new.assert().success();
 
-//     Command::new("mv")
-//         .arg("../platformer/rust_modules/player.gdns")
-//         .arg("../platformer/player/player.gdns")
-//         .output()
-//         .expect("Unable to move player script");
+    set_current_dir("platformer_modules")?;
 
-//     Command::new("cargo")
-//         .arg("run")
-//         .arg("--manifest-path=../../Cargo.toml")
-//         .arg("destroy")
-//         .arg("Player")
-//         .output()
-//         .expect("Unable to execute cargo run");
+    // 2. Assert that the create commands were successful.
+    let mut cmd_create_player = Command::new("cargo");
+    cmd_create_player
+        .arg("run")
+        .arg("--manifest-path=../../Cargo.toml")
+        .arg("create")
+        .arg("Player");
+    cmd_create_player.assert().success();
+    let mut cmd_create_enemy = Command::new("cargo");
+    cmd_create_enemy
+        .arg("run")
+        .arg("--manifest-path=../../Cargo.toml")
+        .arg("create")
+        .arg("Enemy");
+    cmd_create_enemy.assert().success();
+    let mut cmd_create_level = Command::new("cargo");
+    cmd_create_level
+        .arg("run")
+        .arg("--manifest-path=../../Cargo.toml")
+        .arg("create")
+        .arg("Level");
+    cmd_create_level.assert().success();
+    let mut cmd_create_environment = Command::new("cargo");
+    cmd_create_environment
+        .arg("run")
+        .arg("--manifest-path=../../Cargo.toml")
+        .arg("create")
+        .arg("Environment");
+    cmd_create_environment.assert().success();
+    let mut cmd_create_space = Command::new("cargo");
+    cmd_create_space
+        .arg("run")
+        .arg("--manifest-path=../../Cargo.toml")
+        .arg("create")
+        .arg("Space");
+    cmd_create_space.assert().success();
 
-//     let lib_file = read_to_string("src/lib.rs").expect("Unable to read lib file");
-//     let lib_file_split = lib_file.split("\n").collect::<Vec<&str>>();
+    // 3. Assert that the destroy commands were successful.
+    let mut cmd_destroy_enemy = Command::new("cargo");
+    cmd_destroy_enemy
+        .arg("run")
+        .arg("--manifest-path=../../Cargo.toml")
+        .arg("destroy")
+        .arg("Enemy");
+    cmd_destroy_enemy.assert().success();
+    let mut cmd_destroy_space = Command::new("cargo");
+    cmd_destroy_space
+        .arg("run")
+        .arg("--manifest-path=../../Cargo.toml")
+        .arg("destroy")
+        .arg("Space");
+    cmd_destroy_space.assert().success();
 
-//     let config = read_to_string("godot-rust-cli.json").expect("Unable to read config");
-//     let v: Value = serde_json::from_str(&config)?;
+    set_current_dir("../")?;
 
-//     let mod_file_path = Path::new("src/player.rs");
+    // 4. Assert that the modules that weren't deleted have a gdns file still.
+    let player_gdns_path = Path::new("platformer/rust_modules/player.gdns");
+    let level_gdns_path = Path::new("platformer/rust_modules/level.gdns");
+    let environment_gdns_path = Path::new("platformer/rust_modules/environment.gdns");
+    assert_eq!(player_gdns_path.exists(), true);
+    assert_eq!(level_gdns_path.exists(), true);
+    assert_eq!(environment_gdns_path.exists(), true);
 
-//     let player_gdns_file = Path::new("../platformer/rust_modules/player.gdns");
-//     let player_gdns_file_new = Path::new("../platformer/player/player.gdns");
+    // 4. Assert that the modules that were deleted no longer have a gdns file.
+    let enemy_gdns_path = Path::new("platformer/rust_modules/enemy.gdns");
+    let space_gdns_path = Path::new("platformer/rust_modules/space.gdns");
+    assert_eq!(enemy_gdns_path.exists(), false);
+    assert_eq!(space_gdns_path.exists(), false);
 
-//     assert_eq!(lib_file_split[0], "use gdnative::prelude::*;");
-//     assert_eq!(lib_file_split[1], "");
-//     assert_eq!(lib_file_split[2], "fn init(handle: InitHandle) {}");
-//     assert_eq!(lib_file_split[3], "");
-//     assert_eq!(lib_file_split[4], "godot_init!(init);");
-//     assert_eq!(v["modules"], json!([]));
+    Ok(())
+}
 
-//     assert_eq!(mod_file_path.exists(), false);
-//     assert_eq!(player_gdns_file.exists(), false);
-//     assert_eq!(player_gdns_file_new.exists(), false);
+/// Creates a library and then a module and then moves the module from the
+/// rust_modules folder into its own folder and makes sure that it still gets
+/// deleted.
+#[test]
+fn destroy_moved_module_godot_structure() -> Result<(), Box<dyn Error>> {
+    init_test();
 
-//     set_current_dir("../").expect("Unable to change to parent directory");
+    // 1. Assert that the new command was successful.
+    let mut cmd_new = Command::new("cargo");
+    cmd_new
+        .arg("run")
+        .arg("--manifest-path=../Cargo.toml")
+        .arg("new")
+        .arg("PlatformerModules")
+        .arg("platformer")
+        .arg("--skip-build");
+    cmd_new.assert().success();
 
-//     cleanup_test_files();
+    set_current_dir("platformer_modules")?;
 
-//     Ok(())
-// }
+    // 2. Assert that the create command was successful.
+    let mut cmd_create = Command::new("cargo");
+    cmd_create
+        .arg("run")
+        .arg("--manifest-path=../../Cargo.toml")
+        .arg("create")
+        .arg("Player");
+    cmd_create.assert().success();
+
+    Command::new("mkdir")
+        .arg("../platformer/player")
+        .output()
+        .expect("Unable to create player dir");
+
+    Command::new("mv")
+        .arg("../platformer/rust_modules/player.gdns")
+        .arg("../platformer/player/player.gdns")
+        .output()
+        .expect("Unable to move player script");
+
+    // 3. Assert that the destroy command was successful.
+    let mut cmd_destroy = Command::new("cargo");
+    cmd_destroy
+        .arg("run")
+        .arg("--manifest-path=../../Cargo.toml")
+        .arg("destroy")
+        .arg("Player");
+    cmd_destroy.assert().success();
+
+    set_current_dir("../")?;
+
+    let module_gdns_path_old = Path::new("platformer/rust_modules/player.gdns");
+    let module_gdns_path_new = Path::new("platformer/player/player.gdns");
+
+    assert_eq!(module_gdns_path_old.exists(), false);
+    assert_eq!(module_gdns_path_new.exists(), false);
+
+    cleanup_test_files();
+
+    Ok(())
+}

--- a/tests/command-destroy.rs
+++ b/tests/command-destroy.rs
@@ -1,262 +1,262 @@
-use assert_cmd::prelude::*;
+// use assert_cmd::prelude::*;
 
-use serde_json::{json, Value};
-use std::env::set_current_dir;
-use std::error::Error;
-use std::fs::read_to_string;
-use std::path::Path;
-use std::process::Command;
+// use serde_json::{json, Value};
+// use std::env::set_current_dir;
+// use std::error::Error;
+// use std::fs::read_to_string;
+// use std::path::Path;
+// use std::process::Command;
 
-mod test_utilities;
-use test_utilities::{cleanup_test_files, init_test};
+// mod test_utilities;
+// use test_utilities::{cleanup_test_files, init_test};
 
-#[test]
-fn destroy_remove_module_from_library_lib_file_and_godot_project_rust_modules(
-) -> Result<(), Box<dyn Error>> {
-    init_test();
+// #[test]
+// fn destroy_remove_module_from_library_lib_file_and_godot_project_rust_modules(
+// ) -> Result<(), Box<dyn Error>> {
+//     init_test();
 
-    let mut cmd = Command::cargo_bin("godot-rust-cli")?;
-    cmd.arg("new")
-        .arg("platformer_modules")
-        .arg("platformer")
-        .arg("--skip-build");
+//     let mut cmd = Command::cargo_bin("godot-rust-cli")?;
+//     cmd.arg("new")
+//         .arg("platformer_modules")
+//         .arg("platformer")
+//         .arg("--skip-build");
 
-    cmd.assert().success();
+//     cmd.assert().success();
 
-    set_current_dir("platformer_modules").expect("Unable to change to library directory");
-    Command::new("cargo")
-        .arg("run")
-        .arg("--manifest-path=../../Cargo.toml")
-        .arg("create")
-        .arg("Player")
-        .output()
-        .expect("Unable to execute cargo run");
-    Command::new("cargo")
-        .arg("run")
-        .arg("--manifest-path=../../Cargo.toml")
-        .arg("destroy")
-        .arg("Player")
-        .output()
-        .expect("Unable to execute cargo run");
+//     set_current_dir("platformer_modules").expect("Unable to change to library directory");
+//     Command::new("cargo")
+//         .arg("run")
+//         .arg("--manifest-path=../../Cargo.toml")
+//         .arg("create")
+//         .arg("Player")
+//         .output()
+//         .expect("Unable to execute cargo run");
+//     Command::new("cargo")
+//         .arg("run")
+//         .arg("--manifest-path=../../Cargo.toml")
+//         .arg("destroy")
+//         .arg("Player")
+//         .output()
+//         .expect("Unable to execute cargo run");
 
-    let lib_file = read_to_string("src/lib.rs").expect("Unable to read lib file");
-    let lib_file_split = lib_file.split("\n").collect::<Vec<&str>>();
+//     let lib_file = read_to_string("src/lib.rs").expect("Unable to read lib file");
+//     let lib_file_split = lib_file.split("\n").collect::<Vec<&str>>();
 
-    let config = read_to_string("godot-rust-cli.json").expect("Unable to read config");
-    let v: Value = serde_json::from_str(&config)?;
+//     let config = read_to_string("godot-rust-cli.json").expect("Unable to read config");
+//     let v: Value = serde_json::from_str(&config)?;
 
-    let mod_file_path = Path::new("src/player.rs");
+//     let mod_file_path = Path::new("src/player.rs");
 
-    let player_gdns_file = Path::new("../platformer/rust_modules/player.gdns");
+//     let player_gdns_file = Path::new("../platformer/rust_modules/player.gdns");
 
-    assert_eq!(lib_file_split[0], "use gdnative::prelude::*;");
-    assert_eq!(lib_file_split[1], "");
-    assert_eq!(lib_file_split[2], "fn init(handle: InitHandle) {}");
-    assert_eq!(lib_file_split[3], "");
-    assert_eq!(lib_file_split[4], "godot_init!(init);");
-    assert_eq!(v["modules"], json!([]));
+//     assert_eq!(lib_file_split[0], "use gdnative::prelude::*;");
+//     assert_eq!(lib_file_split[1], "");
+//     assert_eq!(lib_file_split[2], "fn init(handle: InitHandle) {}");
+//     assert_eq!(lib_file_split[3], "");
+//     assert_eq!(lib_file_split[4], "godot_init!(init);");
+//     assert_eq!(v["modules"], json!([]));
 
-    assert_eq!(mod_file_path.exists(), false);
-    assert_eq!(player_gdns_file.exists(), false);
+//     assert_eq!(mod_file_path.exists(), false);
+//     assert_eq!(player_gdns_file.exists(), false);
 
-    set_current_dir("../").expect("Unable to change to parent directory");
+//     set_current_dir("../").expect("Unable to change to parent directory");
 
-    cleanup_test_files();
+//     cleanup_test_files();
 
-    Ok(())
-}
+//     Ok(())
+// }
 
-#[test]
-fn destroy_create_five_modules_remove_two_modules() -> Result<(), Box<dyn Error>> {
-    init_test();
+// #[test]
+// fn destroy_create_five_modules_remove_two_modules() -> Result<(), Box<dyn Error>> {
+//     init_test();
 
-    let mut cmd = Command::cargo_bin("godot-rust-cli")?;
-    cmd.arg("new")
-        .arg("platformer_modules")
-        .arg("platformer")
-        .arg("--skip-build");
+//     let mut cmd = Command::cargo_bin("godot-rust-cli")?;
+//     cmd.arg("new")
+//         .arg("platformer_modules")
+//         .arg("platformer")
+//         .arg("--skip-build");
 
-    cmd.assert().success();
+//     cmd.assert().success();
 
-    set_current_dir("platformer_modules").expect("Unable to change to library directory");
-    Command::new("cargo")
-        .arg("run")
-        .arg("--manifest-path=../../Cargo.toml")
-        .arg("create")
-        .arg("Player")
-        .output()
-        .expect("Unable to execute cargo run");
-    Command::new("cargo")
-        .arg("run")
-        .arg("--manifest-path=../../Cargo.toml")
-        .arg("create")
-        .arg("MainScene")
-        .output()
-        .expect("Unable to execute cargo run");
-    Command::new("cargo")
-        .arg("run")
-        .arg("--manifest-path=../../Cargo.toml")
-        .arg("create")
-        .arg("Ship")
-        .output()
-        .expect("Unable to execute cargo run");
-    Command::new("cargo")
-        .arg("run")
-        .arg("--manifest-path=../../Cargo.toml")
-        .arg("create")
-        .arg("Vehicle")
-        .output()
-        .expect("Unable to execute cargo run");
-    Command::new("cargo")
-        .arg("run")
-        .arg("--manifest-path=../../Cargo.toml")
-        .arg("create")
-        .arg("Enemy")
-        .output()
-        .expect("Unable to execute cargo run");
-    Command::new("cargo")
-        .arg("run")
-        .arg("--manifest-path=../../Cargo.toml")
-        .arg("destroy")
-        .arg("Ship")
-        .output()
-        .expect("Unable to execute cargo run");
-    Command::new("cargo")
-        .arg("run")
-        .arg("--manifest-path=../../Cargo.toml")
-        .arg("destroy")
-        .arg("Enemy")
-        .output()
-        .expect("Unable to execute cargo run");
+//     set_current_dir("platformer_modules").expect("Unable to change to library directory");
+//     Command::new("cargo")
+//         .arg("run")
+//         .arg("--manifest-path=../../Cargo.toml")
+//         .arg("create")
+//         .arg("Player")
+//         .output()
+//         .expect("Unable to execute cargo run");
+//     Command::new("cargo")
+//         .arg("run")
+//         .arg("--manifest-path=../../Cargo.toml")
+//         .arg("create")
+//         .arg("MainScene")
+//         .output()
+//         .expect("Unable to execute cargo run");
+//     Command::new("cargo")
+//         .arg("run")
+//         .arg("--manifest-path=../../Cargo.toml")
+//         .arg("create")
+//         .arg("Ship")
+//         .output()
+//         .expect("Unable to execute cargo run");
+//     Command::new("cargo")
+//         .arg("run")
+//         .arg("--manifest-path=../../Cargo.toml")
+//         .arg("create")
+//         .arg("Vehicle")
+//         .output()
+//         .expect("Unable to execute cargo run");
+//     Command::new("cargo")
+//         .arg("run")
+//         .arg("--manifest-path=../../Cargo.toml")
+//         .arg("create")
+//         .arg("Enemy")
+//         .output()
+//         .expect("Unable to execute cargo run");
+//     Command::new("cargo")
+//         .arg("run")
+//         .arg("--manifest-path=../../Cargo.toml")
+//         .arg("destroy")
+//         .arg("Ship")
+//         .output()
+//         .expect("Unable to execute cargo run");
+//     Command::new("cargo")
+//         .arg("run")
+//         .arg("--manifest-path=../../Cargo.toml")
+//         .arg("destroy")
+//         .arg("Enemy")
+//         .output()
+//         .expect("Unable to execute cargo run");
 
-    let lib_file = read_to_string("src/lib.rs").expect("Unable to read lib file");
-    let lib_file_split = lib_file.split("\n").collect::<Vec<&str>>();
+//     let lib_file = read_to_string("src/lib.rs").expect("Unable to read lib file");
+//     let lib_file_split = lib_file.split("\n").collect::<Vec<&str>>();
 
-    let config = read_to_string("godot-rust-cli.json").expect("Unable to read config");
-    let v: Value = serde_json::from_str(&config)?;
+//     let config = read_to_string("godot-rust-cli.json").expect("Unable to read config");
+//     let v: Value = serde_json::from_str(&config)?;
 
-    let player_mod_file_path = Path::new("src/player.rs");
-    let main_scene_mod_file_path = Path::new("src/main_scene.rs");
-    let ship_mod_file_path = Path::new("src/ship.rs");
-    let vehicle_mod_file_path = Path::new("src/vehicle.rs");
-    let enemy_mod_file_path = Path::new("src/enemy.rs");
+//     let player_mod_file_path = Path::new("src/player.rs");
+//     let main_scene_mod_file_path = Path::new("src/main_scene.rs");
+//     let ship_mod_file_path = Path::new("src/ship.rs");
+//     let vehicle_mod_file_path = Path::new("src/vehicle.rs");
+//     let enemy_mod_file_path = Path::new("src/enemy.rs");
 
-    let player_gdns_file = Path::new("../platformer/rust_modules/player.gdns");
-    let main_scene_gdns_file = Path::new("../platformer/rust_modules/main_scene.gdns");
-    let ship_gdns_file = Path::new("../platformer/rust_modules/ship.gdns");
-    let vehicle_gdns_file = Path::new("../platformer/rust_modules/vehicle.gdns");
-    let enemy_gdns_file = Path::new("../platformer/rust_modules/enemy.gdns");
+//     let player_gdns_file = Path::new("../platformer/rust_modules/player.gdns");
+//     let main_scene_gdns_file = Path::new("../platformer/rust_modules/main_scene.gdns");
+//     let ship_gdns_file = Path::new("../platformer/rust_modules/ship.gdns");
+//     let vehicle_gdns_file = Path::new("../platformer/rust_modules/vehicle.gdns");
+//     let enemy_gdns_file = Path::new("../platformer/rust_modules/enemy.gdns");
 
-    assert_eq!(lib_file_split[0], "mod main_scene;");
-    assert_eq!(lib_file_split[1], "mod player;");
-    assert_eq!(lib_file_split[2], "mod vehicle;");
-    assert_eq!(lib_file_split[3], "use gdnative::prelude::*;");
-    assert_eq!(lib_file_split[4], "");
-    assert_eq!(lib_file_split[5], "fn init(handle: InitHandle) {");
-    assert_eq!(
-        lib_file_split[6].trim(),
-        "handle.add_class::<player::Player>();"
-    );
-    assert_eq!(
-        lib_file_split[7].trim(),
-        "handle.add_class::<vehicle::Vehicle>();"
-    );
-    assert_eq!(
-        lib_file_split[8].trim(),
-        "handle.add_class::<main_scene::MainScene>();"
-    );
-    assert_eq!(lib_file_split[9], "}");
-    assert_eq!(lib_file_split[10], "");
-    assert_eq!(lib_file_split[11], "godot_init!(init);");
+//     assert_eq!(lib_file_split[0], "mod main_scene;");
+//     assert_eq!(lib_file_split[1], "mod player;");
+//     assert_eq!(lib_file_split[2], "mod vehicle;");
+//     assert_eq!(lib_file_split[3], "use gdnative::prelude::*;");
+//     assert_eq!(lib_file_split[4], "");
+//     assert_eq!(lib_file_split[5], "fn init(handle: InitHandle) {");
+//     assert_eq!(
+//         lib_file_split[6].trim(),
+//         "handle.add_class::<player::Player>();"
+//     );
+//     assert_eq!(
+//         lib_file_split[7].trim(),
+//         "handle.add_class::<vehicle::Vehicle>();"
+//     );
+//     assert_eq!(
+//         lib_file_split[8].trim(),
+//         "handle.add_class::<main_scene::MainScene>();"
+//     );
+//     assert_eq!(lib_file_split[9], "}");
+//     assert_eq!(lib_file_split[10], "");
+//     assert_eq!(lib_file_split[11], "godot_init!(init);");
 
-    assert_eq!(v["modules"][0], "Player");
-    assert_eq!(v["modules"][1], "MainScene");
-    assert_eq!(v["modules"][2], "Vehicle");
+//     assert_eq!(v["modules"][0], "Player");
+//     assert_eq!(v["modules"][1], "MainScene");
+//     assert_eq!(v["modules"][2], "Vehicle");
 
-    assert_eq!(player_mod_file_path.exists(), true);
-    assert_eq!(main_scene_mod_file_path.exists(), true);
-    assert_eq!(vehicle_mod_file_path.exists(), true);
-    assert_eq!(enemy_mod_file_path.exists(), false);
-    assert_eq!(ship_mod_file_path.exists(), false);
+//     assert_eq!(player_mod_file_path.exists(), true);
+//     assert_eq!(main_scene_mod_file_path.exists(), true);
+//     assert_eq!(vehicle_mod_file_path.exists(), true);
+//     assert_eq!(enemy_mod_file_path.exists(), false);
+//     assert_eq!(ship_mod_file_path.exists(), false);
 
-    assert_eq!(player_gdns_file.exists(), true);
-    assert_eq!(main_scene_gdns_file.exists(), true);
-    assert_eq!(vehicle_gdns_file.exists(), true);
-    assert_eq!(enemy_gdns_file.exists(), false);
-    assert_eq!(ship_gdns_file.exists(), false);
+//     assert_eq!(player_gdns_file.exists(), true);
+//     assert_eq!(main_scene_gdns_file.exists(), true);
+//     assert_eq!(vehicle_gdns_file.exists(), true);
+//     assert_eq!(enemy_gdns_file.exists(), false);
+//     assert_eq!(ship_gdns_file.exists(), false);
 
-    set_current_dir("../").expect("Unable to change to parent directory");
+//     set_current_dir("../").expect("Unable to change to parent directory");
 
-    cleanup_test_files();
+//     cleanup_test_files();
 
-    Ok(())
-}
+//     Ok(())
+// }
 
-#[test]
-fn destroy_remove_moved_module() -> Result<(), Box<dyn Error>> {
-    init_test();
+// #[test]
+// fn destroy_remove_moved_module() -> Result<(), Box<dyn Error>> {
+//     init_test();
 
-    let mut cmd = Command::cargo_bin("godot-rust-cli")?;
-    cmd.arg("new")
-        .arg("platformer_modules")
-        .arg("platformer")
-        .arg("--skip-build");
+//     let mut cmd = Command::cargo_bin("godot-rust-cli")?;
+//     cmd.arg("new")
+//         .arg("platformer_modules")
+//         .arg("platformer")
+//         .arg("--skip-build");
 
-    cmd.assert().success();
+//     cmd.assert().success();
 
-    set_current_dir("platformer_modules").expect("Unable to change to library directory");
-    Command::new("cargo")
-        .arg("run")
-        .arg("--manifest-path=../../Cargo.toml")
-        .arg("create")
-        .arg("Player")
-        .output()
-        .expect("Unable to execute cargo run");
+//     set_current_dir("platformer_modules").expect("Unable to change to library directory");
+//     Command::new("cargo")
+//         .arg("run")
+//         .arg("--manifest-path=../../Cargo.toml")
+//         .arg("create")
+//         .arg("Player")
+//         .output()
+//         .expect("Unable to execute cargo run");
 
-    Command::new("mkdir")
-        .arg("../platformer/player")
-        .output()
-        .expect("Unable to create player dir");
+//     Command::new("mkdir")
+//         .arg("../platformer/player")
+//         .output()
+//         .expect("Unable to create player dir");
 
-    Command::new("mv")
-        .arg("../platformer/rust_modules/player.gdns")
-        .arg("../platformer/player/player.gdns")
-        .output()
-        .expect("Unable to move player script");
+//     Command::new("mv")
+//         .arg("../platformer/rust_modules/player.gdns")
+//         .arg("../platformer/player/player.gdns")
+//         .output()
+//         .expect("Unable to move player script");
 
-    Command::new("cargo")
-        .arg("run")
-        .arg("--manifest-path=../../Cargo.toml")
-        .arg("destroy")
-        .arg("Player")
-        .output()
-        .expect("Unable to execute cargo run");
+//     Command::new("cargo")
+//         .arg("run")
+//         .arg("--manifest-path=../../Cargo.toml")
+//         .arg("destroy")
+//         .arg("Player")
+//         .output()
+//         .expect("Unable to execute cargo run");
 
-    let lib_file = read_to_string("src/lib.rs").expect("Unable to read lib file");
-    let lib_file_split = lib_file.split("\n").collect::<Vec<&str>>();
+//     let lib_file = read_to_string("src/lib.rs").expect("Unable to read lib file");
+//     let lib_file_split = lib_file.split("\n").collect::<Vec<&str>>();
 
-    let config = read_to_string("godot-rust-cli.json").expect("Unable to read config");
-    let v: Value = serde_json::from_str(&config)?;
+//     let config = read_to_string("godot-rust-cli.json").expect("Unable to read config");
+//     let v: Value = serde_json::from_str(&config)?;
 
-    let mod_file_path = Path::new("src/player.rs");
+//     let mod_file_path = Path::new("src/player.rs");
 
-    let player_gdns_file = Path::new("../platformer/rust_modules/player.gdns");
-    let player_gdns_file_new = Path::new("../platformer/player/player.gdns");
+//     let player_gdns_file = Path::new("../platformer/rust_modules/player.gdns");
+//     let player_gdns_file_new = Path::new("../platformer/player/player.gdns");
 
-    assert_eq!(lib_file_split[0], "use gdnative::prelude::*;");
-    assert_eq!(lib_file_split[1], "");
-    assert_eq!(lib_file_split[2], "fn init(handle: InitHandle) {}");
-    assert_eq!(lib_file_split[3], "");
-    assert_eq!(lib_file_split[4], "godot_init!(init);");
-    assert_eq!(v["modules"], json!([]));
+//     assert_eq!(lib_file_split[0], "use gdnative::prelude::*;");
+//     assert_eq!(lib_file_split[1], "");
+//     assert_eq!(lib_file_split[2], "fn init(handle: InitHandle) {}");
+//     assert_eq!(lib_file_split[3], "");
+//     assert_eq!(lib_file_split[4], "godot_init!(init);");
+//     assert_eq!(v["modules"], json!([]));
 
-    assert_eq!(mod_file_path.exists(), false);
-    assert_eq!(player_gdns_file.exists(), false);
-    assert_eq!(player_gdns_file_new.exists(), false);
+//     assert_eq!(mod_file_path.exists(), false);
+//     assert_eq!(player_gdns_file.exists(), false);
+//     assert_eq!(player_gdns_file_new.exists(), false);
 
-    set_current_dir("../").expect("Unable to change to parent directory");
+//     set_current_dir("../").expect("Unable to change to parent directory");
 
-    cleanup_test_files();
+//     cleanup_test_files();
 
-    Ok(())
-}
+//     Ok(())
+// }

--- a/tests/command-destroy.rs
+++ b/tests/command-destroy.rs
@@ -53,7 +53,10 @@ fn destroy_module_library_structure() -> Result<(), Box<dyn Error>> {
 
     // 5. Assert that the module was removed from the lib file.
     let lib_file_string = read_to_string("src/lib.rs")?;
-    let lib_file_split = lib_file_string.split("\n").collect::<Vec<&str>>();
+    let lib_file_split = lib_file_string
+        .split("\n")
+        .map(|x| x.replace("\r", ""))
+        .collect::<Vec<String>>();
     assert_eq!(lib_file_split[0], "use gdnative::prelude::*;");
     assert_eq!(lib_file_split[1], "");
     assert_eq!(lib_file_split[2], "fn init(handle: InitHandle) {}");
@@ -206,7 +209,10 @@ fn destroy_modules_library_structure() -> Result<(), Box<dyn Error>> {
 
     // 6. Assert that the modules were removed from the lib file.
     let lib_file_string = read_to_string("src/lib.rs")?;
-    let lib_file_split = lib_file_string.split("\n").collect::<Vec<&str>>();
+    let lib_file_split = lib_file_string
+        .split("\n")
+        .map(|x| x.replace("\r", ""))
+        .collect::<Vec<String>>();
     assert_eq!(lib_file_split[0], "mod environment;");
     assert_eq!(lib_file_split[1], "mod level;");
     assert_eq!(lib_file_split[2], "mod player;");

--- a/tests/command-new.rs
+++ b/tests/command-new.rs
@@ -102,7 +102,7 @@ fn new_create_godot_structure() -> Result<(), Box<dyn Error>> {
 
     // 5. Assert that the contents of the gdnlib file are what we expect.
     let gdnlib_string = read_to_string(gdnlib_path)?;
-    let gdnlib_split = gdnlib_string.split("\r\n").collect::<Vec<&str>>();
+    let gdnlib_split = gdnlib_string.split("\n").collect::<Vec<&str>>();
     assert_eq!(
         gdnlib_split[9],
         "OSX.64=\"res://bin/libplatformer_modules.dylib\""

--- a/tests/command-new.rs
+++ b/tests/command-new.rs
@@ -43,7 +43,10 @@ fn new_create_library_structure() -> Result<(), Box<dyn Error>> {
 
     // 5. Assert that the plugin's initial module is added to the lib file.
     let lib_file_string = read_to_string(lib_file_path)?;
-    let lib_file_split = lib_file_string.split("\n").collect::<Vec<&str>>();
+    let lib_file_split = lib_file_string
+        .split("\n")
+        .map(|x| x.replace("\r", ""))
+        .collect::<Vec<String>>();
     assert_eq!(lib_file_split[0], "use gdnative::prelude::*;");
     assert_eq!(lib_file_split[1], "");
     assert_eq!(lib_file_split[2], "fn init(handle: InitHandle) {}");
@@ -52,7 +55,10 @@ fn new_create_library_structure() -> Result<(), Box<dyn Error>> {
 
     // 6. Assert that the Cargo.toml file of the library is what we expect.
     let cargo_toml_string = read_to_string("platformer_modules/Cargo.toml")?;
-    let cargo_toml_split = cargo_toml_string.split("\n").collect::<Vec<&str>>();
+    let cargo_toml_split = cargo_toml_string
+        .split("\n")
+        .map(|x| x.replace("\r", ""))
+        .collect::<Vec<String>>();
     assert_eq!(cargo_toml_split[0], "[package]");
     assert_eq!(cargo_toml_split[1], "name = \"platformer_modules\"");
     assert_eq!(cargo_toml_split[2], "version = \"0.1.0\"");
@@ -102,7 +108,10 @@ fn new_create_godot_structure() -> Result<(), Box<dyn Error>> {
 
     // 5. Assert that the contents of the gdnlib file are what we expect.
     let gdnlib_string = read_to_string(gdnlib_path)?;
-    let gdnlib_split = gdnlib_string.split("\n").collect::<Vec<&str>>();
+    let gdnlib_split = gdnlib_string
+        .split("\n")
+        .map(|x| x.replace("\r", ""))
+        .collect::<Vec<String>>();
     assert_eq!(
         gdnlib_split[9],
         "OSX.64=\"res://bin/libplatformer_modules.dylib\""

--- a/tests/command-new.rs
+++ b/tests/command-new.rs
@@ -1,180 +1,180 @@
-use assert_cmd::prelude::*;
+// use assert_cmd::prelude::*;
 
-use serde_json::{json, Value};
-use std::error::Error;
-use std::fs::read_to_string;
-use std::path::Path;
-use std::process::Command;
+// use serde_json::{json, Value};
+// use std::error::Error;
+// use std::fs::read_to_string;
+// use std::path::Path;
+// use std::process::Command;
 
-mod test_utilities;
-use test_utilities::{cleanup_test_files, init_test};
+// mod test_utilities;
+// use test_utilities::{cleanup_test_files, init_test};
 
-#[test]
-fn new_library_has_correct_cargo_toml() -> Result<(), Box<dyn Error>> {
-    init_test();
+// #[test]
+// fn new_library_has_correct_cargo_toml() -> Result<(), Box<dyn Error>> {
+//     init_test();
 
-    let mut cmd = Command::cargo_bin("godot-rust-cli")?;
-    cmd.arg("new")
-        .arg("platformer_modules")
-        .arg("platformer")
-        .arg("--skip-build");
+//     let mut cmd = Command::cargo_bin("godot-rust-cli")?;
+//     cmd.arg("new")
+//         .arg("platformer_modules")
+//         .arg("platformer")
+//         .arg("--skip-build");
 
-    cmd.assert().success();
+//     cmd.assert().success();
 
-    let cargo_toml =
-        read_to_string("platformer_modules/Cargo.toml").expect("Unable to read Cargo.toml");
-    let cargo_toml_split = cargo_toml.split("\n").collect::<Vec<&str>>();
+//     let cargo_toml =
+//         read_to_string("platformer_modules/Cargo.toml").expect("Unable to read Cargo.toml");
+//     let cargo_toml_split = cargo_toml.split("\n").collect::<Vec<&str>>();
 
-    assert_eq!(cargo_toml_split[6], "[lib]");
-    assert_eq!(cargo_toml_split[7], "crate-type = [\"cdylib\"]");
-    assert_eq!(cargo_toml_split[9], "[dependencies]");
-    assert_eq!(cargo_toml_split[10], "gdnative = \"0.9.3\"");
+//     assert_eq!(cargo_toml_split[6], "[lib]");
+//     assert_eq!(cargo_toml_split[7], "crate-type = [\"cdylib\"]");
+//     assert_eq!(cargo_toml_split[9], "[dependencies]");
+//     assert_eq!(cargo_toml_split[10], "gdnative = \"0.9.3\"");
 
-    cleanup_test_files();
+//     cleanup_test_files();
 
-    Ok(())
-}
+//     Ok(())
+// }
 
-#[test]
-fn new_godot_project_has_rust_modules_directory() -> Result<(), Box<dyn Error>> {
-    init_test();
+// #[test]
+// fn new_godot_project_has_rust_modules_directory() -> Result<(), Box<dyn Error>> {
+//     init_test();
 
-    let mut cmd = Command::cargo_bin("godot-rust-cli")?;
-    cmd.arg("new")
-        .arg("platformer_modules")
-        .arg("platformer")
-        .arg("--skip-build");
+//     let mut cmd = Command::cargo_bin("godot-rust-cli")?;
+//     cmd.arg("new")
+//         .arg("platformer_modules")
+//         .arg("platformer")
+//         .arg("--skip-build");
 
-    cmd.assert().success();
+//     cmd.assert().success();
 
-    let rust_modules = Path::new("./platformer/rust_modules");
-    assert_eq!(rust_modules.exists(), true);
+//     let rust_modules = Path::new("./platformer/rust_modules");
+//     assert_eq!(rust_modules.exists(), true);
 
-    cleanup_test_files();
+//     cleanup_test_files();
 
-    Ok(())
-}
+//     Ok(())
+// }
 
-#[test]
-fn new_library_name_is_snake_case() -> Result<(), Box<dyn Error>> {
-    init_test();
+// #[test]
+// fn new_library_name_is_snake_case() -> Result<(), Box<dyn Error>> {
+//     init_test();
 
-    let mut cmd = Command::cargo_bin("godot-rust-cli")?;
-    cmd.arg("new")
-        .arg("platformer-modules")
-        .arg("platformer")
-        .arg("--skip-build");
+//     let mut cmd = Command::cargo_bin("godot-rust-cli")?;
+//     cmd.arg("new")
+//         .arg("platformer-modules")
+//         .arg("platformer")
+//         .arg("--skip-build");
 
-    cmd.assert().success();
+//     cmd.assert().success();
 
-    let cargo_toml =
-        read_to_string("platformer_modules/Cargo.toml").expect("Unable to read Cargo.toml");
+//     let cargo_toml =
+//         read_to_string("platformer_modules/Cargo.toml").expect("Unable to read Cargo.toml");
 
-    assert_eq!(cargo_toml.is_empty(), false);
+//     assert_eq!(cargo_toml.is_empty(), false);
 
-    cleanup_test_files();
+//     cleanup_test_files();
 
-    Ok(())
-}
+//     Ok(())
+// }
 
-#[test]
-fn new_library_has_correct_project_json() -> Result<(), Box<dyn Error>> {
-    init_test();
+// #[test]
+// fn new_library_has_correct_project_json() -> Result<(), Box<dyn Error>> {
+//     init_test();
 
-    let mut cmd = Command::cargo_bin("godot-rust-cli")?;
-    cmd.arg("new")
-        .arg("platformer_modules")
-        .arg("platformer")
-        .arg("--skip-build");
+//     let mut cmd = Command::cargo_bin("godot-rust-cli")?;
+//     cmd.arg("new")
+//         .arg("platformer_modules")
+//         .arg("platformer")
+//         .arg("--skip-build");
 
-    cmd.assert().success();
+//     cmd.assert().success();
 
-    let config = read_to_string("platformer_modules/godot-rust-cli.json").expect("Unable to read config");
-    let v: Value = serde_json::from_str(&config)?;
+//     let config = read_to_string("platformer_modules/godot-rust-cli.json").expect("Unable to read config");
+//     let v: Value = serde_json::from_str(&config)?;
 
-    let gdnlib_path = Path::new("platformer/platformer_modules.gdnlib");
+//     let gdnlib_path = Path::new("platformer/platformer_modules.gdnlib");
 
-    assert_eq!(v["godot_project_name"], "platformer");
-    assert_eq!(v["modules"], json!([]));
+//     assert_eq!(v["godot_project_name"], "platformer");
+//     assert_eq!(v["modules"], json!([]));
 
-    assert_eq!(gdnlib_path.exists(), true);
+//     assert_eq!(gdnlib_path.exists(), true);
 
-    cleanup_test_files();
+//     cleanup_test_files();
 
-    Ok(())
-}
+//     Ok(())
+// }
 
-#[test]
-fn new_has_initial_lib_file() -> Result<(), Box<dyn Error>> {
-    init_test();
+// #[test]
+// fn new_has_initial_lib_file() -> Result<(), Box<dyn Error>> {
+//     init_test();
 
-    let mut cmd = Command::cargo_bin("godot-rust-cli")?;
-    cmd.arg("new")
-        .arg("platformer_modules")
-        .arg("platformer")
-        .arg("--skip-build");
+//     let mut cmd = Command::cargo_bin("godot-rust-cli")?;
+//     cmd.arg("new")
+//         .arg("platformer_modules")
+//         .arg("platformer")
+//         .arg("--skip-build");
 
-    cmd.assert().success();
+//     cmd.assert().success();
 
-    let lib = read_to_string("platformer_modules/src/lib.rs").expect("Unable to read lib file");
-    let lib_split = lib.split("\n").collect::<Vec<&str>>();
+//     let lib = read_to_string("platformer_modules/src/lib.rs").expect("Unable to read lib file");
+//     let lib_split = lib.split("\n").collect::<Vec<&str>>();
 
-    assert_eq!(lib_split[0], "use gdnative::prelude::*;");
-    assert_eq!(lib_split[1], "");
-    assert_eq!(lib_split[2], "fn init(handle: InitHandle) {}");
-    assert_eq!(lib_split[3], "");
-    assert_eq!(lib_split[4], "godot_init!(init);");
+//     assert_eq!(lib_split[0], "use gdnative::prelude::*;");
+//     assert_eq!(lib_split[1], "");
+//     assert_eq!(lib_split[2], "fn init(handle: InitHandle) {}");
+//     assert_eq!(lib_split[3], "");
+//     assert_eq!(lib_split[4], "godot_init!(init);");
 
-    cleanup_test_files();
+//     cleanup_test_files();
 
-    Ok(())
-}
+//     Ok(())
+// }
 
-#[test]
-fn new_godot_project_has_correct_gdnlib_file() -> Result<(), Box<dyn Error>> {
-    init_test();
+// #[test]
+// fn new_godot_project_has_correct_gdnlib_file() -> Result<(), Box<dyn Error>> {
+//     init_test();
 
-    let mut cmd = Command::cargo_bin("godot-rust-cli")?;
-    cmd.arg("new")
-        .arg("platformer_modules")
-        .arg("platformer")
-        .arg("--skip-build");
+//     let mut cmd = Command::cargo_bin("godot-rust-cli")?;
+//     cmd.arg("new")
+//         .arg("platformer_modules")
+//         .arg("platformer")
+//         .arg("--skip-build");
 
-    cmd.assert().success();
+//     cmd.assert().success();
 
-    let gdnlib =
-        read_to_string("platformer/platformer_modules.gdnlib").expect("Unable to read gdnlib");
-    let gdnlib_split = gdnlib.split("\n").collect::<Vec<&str>>();
+//     let gdnlib =
+//         read_to_string("platformer/platformer_modules.gdnlib").expect("Unable to read gdnlib");
+//     let gdnlib_split = gdnlib.split("\n").collect::<Vec<&str>>();
 
-    assert_eq!(gdnlib_split[0].trim(), "[general]");
-    assert_eq!(gdnlib_split[1].trim(), "");
-    assert_eq!(gdnlib_split[2].trim(), "singleton=false");
-    assert_eq!(gdnlib_split[3].trim(), "load_once=true");
-    assert_eq!(gdnlib_split[4].trim(), "symbol_prefix=\"godot_\"");
-    assert_eq!(gdnlib_split[5].trim(), "reloadable=true");
-    assert_eq!(gdnlib_split[6].trim(), "");
-    assert_eq!(gdnlib_split[7].trim(), "[entry]");
-    assert_eq!(gdnlib_split[8].trim(), "");
-    assert_eq!(
-        gdnlib_split[9].trim(),
-        "OSX.64=\"res://bin/libplatformer_modules.dylib\""
-    );
-    assert_eq!(
-        gdnlib_split[10].trim(),
-        "Windows.64=\"res://bin/platformer_modules.dll\""
-    );
-    assert_eq!(
-        gdnlib_split[11].trim(),
-        "X11.64=\"res://bin/libplatformer_modules.so\""
-    );
-    assert_eq!(gdnlib_split[12].trim(), "");
-    assert_eq!(gdnlib_split[13].trim(), "[dependencies]");
-    assert_eq!(gdnlib_split[14].trim(), "");
-    assert_eq!(gdnlib_split[15].trim(), "OSX.64=[  ]");
-    assert_eq!(gdnlib_split[16].trim(), "Windows.64=[  ]");
-    assert_eq!(gdnlib_split[17].trim(), "X11.64=[  ]");
+//     assert_eq!(gdnlib_split[0].trim(), "[general]");
+//     assert_eq!(gdnlib_split[1].trim(), "");
+//     assert_eq!(gdnlib_split[2].trim(), "singleton=false");
+//     assert_eq!(gdnlib_split[3].trim(), "load_once=true");
+//     assert_eq!(gdnlib_split[4].trim(), "symbol_prefix=\"godot_\"");
+//     assert_eq!(gdnlib_split[5].trim(), "reloadable=true");
+//     assert_eq!(gdnlib_split[6].trim(), "");
+//     assert_eq!(gdnlib_split[7].trim(), "[entry]");
+//     assert_eq!(gdnlib_split[8].trim(), "");
+//     assert_eq!(
+//         gdnlib_split[9].trim(),
+//         "OSX.64=\"res://bin/libplatformer_modules.dylib\""
+//     );
+//     assert_eq!(
+//         gdnlib_split[10].trim(),
+//         "Windows.64=\"res://bin/platformer_modules.dll\""
+//     );
+//     assert_eq!(
+//         gdnlib_split[11].trim(),
+//         "X11.64=\"res://bin/libplatformer_modules.so\""
+//     );
+//     assert_eq!(gdnlib_split[12].trim(), "");
+//     assert_eq!(gdnlib_split[13].trim(), "[dependencies]");
+//     assert_eq!(gdnlib_split[14].trim(), "");
+//     assert_eq!(gdnlib_split[15].trim(), "OSX.64=[  ]");
+//     assert_eq!(gdnlib_split[16].trim(), "Windows.64=[  ]");
+//     assert_eq!(gdnlib_split[17].trim(), "X11.64=[  ]");
 
-    cleanup_test_files();
+//     cleanup_test_files();
 
-    Ok(())
-}
+//     Ok(())
+// }

--- a/tests/command-plugin.rs
+++ b/tests/command-plugin.rs
@@ -115,7 +115,7 @@ fn plugin_create_godot_structure() -> Result<(), Box<dyn Error>> {
 
     // 6. Assert that the contents of the `plugin.cfg` are what we expect.
     let plugin_cfg_string = read_to_string(plugin_cfg_path)?;
-    let plugin_cfg_split = plugin_cfg_string.split("\r\n").collect::<Vec<&str>>();
+    let plugin_cfg_split = plugin_cfg_string.split("\n").collect::<Vec<&str>>();
     assert_eq!(plugin_cfg_split[0], "[plugin]");
     assert_eq!(plugin_cfg_split[1], "name = \"Directory Browser\"");
     assert_eq!(plugin_cfg_split[5], "script = \"directory_browser.gdns\"");
@@ -126,7 +126,7 @@ fn plugin_create_godot_structure() -> Result<(), Box<dyn Error>> {
 
     // 8. Assert that the contents of the plugin's gdns file are what we expect.
     let plugin_gdns_string = read_to_string(plugin_gdns_path)?;
-    let plugin_gdns_split = plugin_gdns_string.split("\r\n").collect::<Vec<&str>>();
+    let plugin_gdns_split = plugin_gdns_string.split("\n").collect::<Vec<&str>>();
     assert_eq!(plugin_gdns_split[2], "[ext_resource path=\"res://addons/directory_browser/directory_browser.gdnlib\" type=\"GDNativeLibrary\" id=1]");
     assert_eq!(plugin_gdns_split[6], "resource_name = \"DirectoryBrowser\"");
     assert_eq!(plugin_gdns_split[7], "class_name = \"DirectoryBrowser\"");
@@ -138,7 +138,7 @@ fn plugin_create_godot_structure() -> Result<(), Box<dyn Error>> {
 
     // 10. Assert that the contents of the plugin's gdnlib file are what we expect.
     let plugin_gdnlib_string = read_to_string(plugin_gdnlib_path)?;
-    let plugin_gdnlib_split = plugin_gdnlib_string.split("\r\n").collect::<Vec<&str>>();
+    let plugin_gdnlib_split = plugin_gdnlib_string.split("\n").collect::<Vec<&str>>();
     assert_eq!(
         plugin_gdnlib_split[9],
         "OSX.64=\"res://addons/directory_browser/bin/libdirectory_browser.dylib\""
@@ -282,7 +282,7 @@ fn plugin_create_module_godot_structure() -> Result<(), Box<dyn Error>> {
 
     // 8. Assert that the contents of the plugin's gdns file are what we expect.
     let module_gdns_string = read_to_string(module_gdns_path)?;
-    let module_gdns_split = module_gdns_string.split("\r\n").collect::<Vec<&str>>();
+    let module_gdns_split = module_gdns_string.split("\n").collect::<Vec<&str>>();
     assert_eq!(module_gdns_split[2], "[ext_resource path=\"res://addons/directory_browser/directory_browser.gdnlib\" type=\"GDNativeLibrary\" id=1]");
     assert_eq!(module_gdns_split[6], "resource_name = \"Explorer\"");
     assert_eq!(module_gdns_split[7], "class_name = \"Explorer\"");

--- a/tests/command-plugin.rs
+++ b/tests/command-plugin.rs
@@ -8,434 +8,403 @@ use std::path::Path;
 use std::process::Command;
 
 mod test_utilities;
-use test_utilities::{cleanup_test_files, init_test};
+use test_utilities::{cleanup_test_files, init_test, BUILD_FILE_PREFIX, BUILD_FILE_TYPE};
 
+/// Creates a plugin and checks that all of the files in the library exist and
+/// that their values are what they should be.
 #[test]
-fn plugin_add_name_to_library_project_toml() -> Result<(), Box<dyn Error>> {
+fn plugin_create_library_structure() -> Result<(), Box<dyn Error>> {
     init_test();
 
-    let mut cmd = Command::cargo_bin("godot-rust-cli")?;
-    cmd.arg("new")
-        .arg("platformer_modules")
+    // 1. Assert that the plugin command was successful.
+    let mut cmd = Command::new("cargo");
+    cmd.arg("run")
+        .arg("--manifest-path=../Cargo.toml")
+        .arg("new")
+        .arg("Directory Browser")
         .arg("platformer")
+        .arg("--plugin")
         .arg("--skip-build");
-
     cmd.assert().success();
 
-    set_current_dir("platformer_modules").expect("Unable to change to library directory");
-    Command::new("cargo")
-        .arg("run")
-        .arg("--manifest-path=../../Cargo.toml")
-        .arg("plugin")
-        .arg("Directory Browser")
-        .output()
-        .expect("Unable to execute cargo run");
+    // 2. Assert that the library directory for the plugin was created.
+    let plugin_library_dir = Path::new("directory_browser");
+    assert_eq!(plugin_library_dir.exists(), true);
 
-    let config = read_to_string("godot-rust-cli.json").expect("Unable to read config");
-    let v: Value = serde_json::from_str(&config)?;
+    set_current_dir(plugin_library_dir)?;
 
-    assert_eq!(v["godot_project_name"], "platformer");
-    assert_eq!(v["modules"][0], "DirectoryBrowser");
+    // 3: Assert that the config is what it should be.
+    let config = read_to_string("godot-rust-cli.json")?;
+    let config_json: Value = serde_json::from_str(&config)?;
+    assert_eq!(config_json["name"], "Directory Browser");
+    assert_eq!(config_json["godot_project_name"], "platformer");
+    assert_eq!(config_json["is_plugin"], true);
+    assert_eq!(config_json["modules"], json!(["Directory Browser"]));
 
-    set_current_dir("../").expect("Unable to change to parent directory");
+    // 4. Assert that by default the plugin should have a module with the name of the plugin.
+    let plugin_module_path = Path::new("src/directory_browser.rs");
+    assert_eq!(plugin_module_path.exists(), true);
 
-    cleanup_test_files();
-
-    Ok(())
-}
-
-#[test]
-fn plugin_has_correct_plugin_cfg_in_godot_project() -> Result<(), Box<dyn Error>> {
-    init_test();
-
-    let mut cmd = Command::cargo_bin("godot-rust-cli")?;
-    cmd.arg("new")
-        .arg("platformer_modules")
-        .arg("platformer")
-        .arg("--skip-build");
-
-    cmd.assert().success();
-
-    set_current_dir("platformer_modules").expect("Unable to change to library directory");
-    Command::new("cargo")
-        .arg("run")
-        .arg("--manifest-path=../../Cargo.toml")
-        .arg("plugin")
-        .arg("Directory Browser")
-        .output()
-        .expect("Unable to execute cargo run");
-
-    let plugin_config = read_to_string("../platformer/addons/directory_browser/plugin.cfg")
-        .expect("Unable to read gdnlib");
-    let plugin_config_split = plugin_config.split("\n").collect::<Vec<&str>>();
-
-    assert_eq!(plugin_config_split[0].trim(), "[plugin]");
+    // 5. Assert that the contents of the plugin's initial module matches the initial tool module.
+    let plugin_module_string = read_to_string(plugin_module_path)?;
+    let plugin_module_split = plugin_module_string.split("\n").collect::<Vec<&str>>();
+    assert_eq!(plugin_module_split[0], "use gdnative::api::EditorPlugin;");
     assert_eq!(
-        plugin_config_split[1].trim(),
-        "name = \"Directory Browser\""
-    );
-    assert_eq!(plugin_config_split[2].trim(), "description = \"\"");
-    assert_eq!(plugin_config_split[3].trim(), "author = \"\"");
-    assert_eq!(plugin_config_split[4].trim(), "version = \"1.0\"");
-    assert_eq!(
-        plugin_config_split[5].trim(),
-        "script = \"../../rust_modules/directory_browser.gdns\""
-    );
-
-    set_current_dir("../").expect("Unable to change to parent directory");
-
-    cleanup_test_files();
-
-    Ok(())
-}
-
-#[test]
-fn plugin_has_correct_initial_module_file() -> Result<(), Box<dyn Error>> {
-    init_test();
-
-    let mut cmd = Command::cargo_bin("godot-rust-cli")?;
-    cmd.arg("new")
-        .arg("platformer_modules")
-        .arg("platformer")
-        .arg("--skip-build");
-
-    cmd.assert().success();
-
-    set_current_dir("platformer_modules").expect("Unable to change to library directory");
-    Command::new("cargo")
-        .arg("run")
-        .arg("--manifest-path=../../Cargo.toml")
-        .arg("plugin")
-        .arg("Directory Browser")
-        .output()
-        .expect("Unable to execute cargo run");
-
-    let plugin_base_gdns =
-        read_to_string("src/directory_browser.rs").expect("Unable to read mod file");
-    let plugin_base_gdns_split = plugin_base_gdns.split("\n").collect::<Vec<&str>>();
-
-    assert_eq!(
-        plugin_base_gdns_split[0],
-        "use gdnative::api::EditorPlugin;"
-    );
-    assert_eq!(
-        plugin_base_gdns_split[1],
-        "use gdnative::nativescript::user_data;"
-    );
-    assert_eq!(plugin_base_gdns_split[2], "");
-    assert_eq!(
-        plugin_base_gdns_split[3],
-        "#[derive(gdnative::NativeClass)]"
-    );
-    assert_eq!(plugin_base_gdns_split[4], "#[inherit(EditorPlugin)]");
-    assert_eq!(
-        plugin_base_gdns_split[5],
+        plugin_module_split[5],
         "#[user_data(user_data::LocalCellData<DirectoryBrowser>)]"
     );
-    assert_eq!(plugin_base_gdns_split[6], "pub struct DirectoryBrowser;");
-    assert_eq!(plugin_base_gdns_split[7], "");
-    assert_eq!(plugin_base_gdns_split[8], "#[gdnative::methods]");
-    assert_eq!(plugin_base_gdns_split[9], "impl DirectoryBrowser {");
+    assert_eq!(plugin_module_split[6], "pub struct DirectoryBrowser;");
+    assert_eq!(plugin_module_split[9], "impl DirectoryBrowser {");
+    assert_eq!(plugin_module_split[11].trim(), "DirectoryBrowser");
+
+    // 6. Assert that the lib file exists.
+    let lib_file_path = Path::new("src/lib.rs");
+    assert_eq!(lib_file_path.exists(), true);
+
+    // 7. Assert that the plugin's initial module is added to the lib file.
+    let lib_file_string = read_to_string(lib_file_path)?;
+    let lib_file_split = lib_file_string.split("\n").collect::<Vec<&str>>();
+    assert_eq!(lib_file_split[0], "mod directory_browser;");
     assert_eq!(
-        plugin_base_gdns_split[10].trim(),
-        "fn new(_owner: &EditorPlugin) -> Self {"
-    );
-    assert_eq!(plugin_base_gdns_split[11].trim(), "DirectoryBrowser");
-    assert_eq!(plugin_base_gdns_split[12].trim(), "}");
-    assert_eq!(plugin_base_gdns_split[13], "");
-    assert_eq!(plugin_base_gdns_split[14].trim(), "#[export]");
-    assert_eq!(
-        plugin_base_gdns_split[15].trim(),
-        "fn _ready(&self, _owner: &EditorPlugin) {"
-    );
-    assert_eq!(
-        plugin_base_gdns_split[16].trim(),
-        "gdnative::godot_print!(\"hello, world.\");"
-    );
-    assert_eq!(plugin_base_gdns_split[17].trim(), "}");
-    assert_eq!(plugin_base_gdns_split[18], "}");
-    assert_eq!(plugin_base_gdns_split[19], "");
-
-    set_current_dir("../").expect("Unable to change to parent directory");
-
-    cleanup_test_files();
-
-    Ok(())
-}
-
-#[test]
-fn plugin_has_correct_gdns_file_in_godot_project_rust_modules() -> Result<(), Box<dyn Error>> {
-    init_test();
-
-    let mut cmd = Command::cargo_bin("godot-rust-cli")?;
-    cmd.arg("new")
-        .arg("platformer_modules")
-        .arg("platformer")
-        .arg("--skip-build");
-
-    cmd.assert().success();
-
-    set_current_dir("platformer_modules").expect("Unable to change to library directory");
-    Command::new("cargo")
-        .arg("run")
-        .arg("--manifest-path=../../Cargo.toml")
-        .arg("plugin")
-        .arg("Directory Browser")
-        .output()
-        .expect("Unable to execute cargo run");
-
-    let plugin_base_gdns = read_to_string("../platformer/rust_modules/directory_browser.gdns")
-        .expect("Unable to read gdnlib");
-    let plugin_base_gdns_split = plugin_base_gdns.split("\n").collect::<Vec<&str>>();
-
-    assert_eq!(
-        plugin_base_gdns_split[0].trim(),
-        "[gd_resource type=\"NativeScript\" load_steps=2 format=2]"
-    );
-    assert_eq!(plugin_base_gdns_split[1].trim(), "");
-    assert_eq!(
-        plugin_base_gdns_split[2].trim(),
-        "[ext_resource path=\"res://platformer_modules.gdnlib\" type=\"GDNativeLibrary\" id=1]"
-    );
-    assert_eq!(plugin_base_gdns_split[3].trim(), "");
-    assert_eq!(plugin_base_gdns_split[4].trim(), "[resource]");
-    assert_eq!(plugin_base_gdns_split[5].trim(), "");
-    assert_eq!(
-        plugin_base_gdns_split[6].trim(),
-        "resource_name = \"DirectoryBrowser\""
-    );
-    assert_eq!(
-        plugin_base_gdns_split[7].trim(),
-        "class_name = \"DirectoryBrowser\""
-    );
-    assert_eq!(plugin_base_gdns_split[8], "library = ExtResource( 1 )");
-
-    set_current_dir("../").expect("Unable to change to parent directory");
-
-    cleanup_test_files();
-
-    Ok(())
-}
-
-#[test]
-fn plugin_mod_and_handle_added_to_lib_file() -> Result<(), Box<dyn Error>> {
-    init_test();
-
-    let mut cmd = Command::cargo_bin("godot-rust-cli")?;
-    cmd.arg("new")
-        .arg("platformer_modules")
-        .arg("platformer")
-        .arg("--skip-build");
-
-    cmd.assert().success();
-
-    set_current_dir("platformer_modules").expect("Unable to change to library directory");
-    Command::new("cargo")
-        .arg("run")
-        .arg("--manifest-path=../../Cargo.toml")
-        .arg("plugin")
-        .arg("Directory Browser")
-        .output()
-        .expect("Unable to execute cargo run");
-
-    let plugin_lib_file = read_to_string("src/lib.rs").expect("Unable to read lib file");
-    let plugin_lib_file_split = plugin_lib_file.split("\n").collect::<Vec<&str>>();
-
-    assert_eq!(plugin_lib_file_split[0], "mod directory_browser;");
-    assert_eq!(
-        plugin_lib_file_split[4].trim(),
+        lib_file_split[4].trim(),
         "handle.add_tool_class::<directory_browser::DirectoryBrowser>();"
     );
 
-    set_current_dir("../").expect("Unable to change to parent directory");
+    set_current_dir("../")?;
 
     cleanup_test_files();
 
     Ok(())
 }
 
+/// Creates a plugin and checks that all of the files in the Godot project
+/// exist and that their values are what they should be.
 #[test]
-fn plugin_destroy_remove_from_library_lib_file_and_godot_project_rust_modules_and_plugin_directory(
-) -> Result<(), Box<dyn Error>> {
+fn plugin_create_godot_structure() -> Result<(), Box<dyn Error>> {
     init_test();
 
-    let mut cmd = Command::cargo_bin("godot-rust-cli")?;
-    cmd.arg("new")
-        .arg("platformer_modules")
+    // 1. Assert that the plugin command was successful.
+    let mut cmd = Command::new("cargo");
+    cmd.arg("run")
+        .arg("--manifest-path=../Cargo.toml")
+        .arg("new")
+        .arg("Directory Browser")
         .arg("platformer")
-        .arg("--skip-build");
-
+        .arg("--plugin");
     cmd.assert().success();
 
-    set_current_dir("platformer_modules").expect("Unable to change to library directory");
-    Command::new("cargo")
-        .arg("run")
-        .arg("--manifest-path=../../Cargo.toml")
-        .arg("plugin")
-        .arg("Directory Browser")
-        .output()
-        .expect("Unable to execute cargo run");
-    Command::new("cargo")
-        .arg("run")
-        .arg("--manifest-path=../../Cargo.toml")
-        .arg("destroy")
-        .arg("Directory Browser")
-        .output()
-        .expect("Unable to execute cargo run");
+    // 2. Assert that the plugin directory in the Godot project was created.
+    let plugin_godot_dir = Path::new("platformer/addons/directory_browser");
+    assert_eq!(plugin_godot_dir.exists(), true);
 
-    let lib_file = read_to_string("src/lib.rs").expect("Unable to read lib file");
-    let lib_file_split = lib_file.split("\n").collect::<Vec<&str>>();
+    // 3. Assert that the dynamic library for the plugin exists in the plugin's bin directory.
+    let plugin_dynamic_library_name = format!(
+        "platformer/addons/directory_browser/bin/{}directory_browser.{}",
+        BUILD_FILE_PREFIX, BUILD_FILE_TYPE
+    );
+    let plugin_dynamic_library_path = Path::new(&plugin_dynamic_library_name);
+    assert_eq!(plugin_dynamic_library_path.exists(), true);
 
-    let config = read_to_string("godot-rust-cli.json").expect("Unable to read config");
-    let v: Value = serde_json::from_str(&config)?;
+    // 4. Assert that the `rust_modules` directory was created in the plugin's directory.
+    let plugin_rust_modules_path = Path::new("platformer/addons/directory_browser/rust_modules");
+    assert_eq!(plugin_rust_modules_path.exists(), true);
 
-    let plugin_file_path = Path::new("src/directory_browser.rs");
-    let plugin_gdns_file = Path::new("../platformer/rust_modules/directory_browser.gdns");
-    let plugin_godot_directory = Path::new("../platformer/addons/directory_browser");
+    // 5. Assert that the `plugin.cfg` file exists.
+    let plugin_cfg_path = Path::new("platformer/addons/directory_browser/plugin.cfg");
+    assert_eq!(plugin_cfg_path.exists(), true);
 
-    assert_eq!(lib_file_split[0], "use gdnative::prelude::*;");
-    assert_eq!(lib_file_split[1], "");
-    assert_eq!(lib_file_split[2], "fn init(handle: InitHandle) {}");
-    assert_eq!(lib_file_split[3], "");
-    assert_eq!(lib_file_split[4], "godot_init!(init);");
-    assert_eq!(v["modules"], json!([]));
-    assert_eq!(plugin_file_path.exists(), false);
-    assert_eq!(plugin_gdns_file.exists(), false);
-    assert_eq!(plugin_godot_directory.exists(), false);
+    // 6. Assert that the contents of the `plugin.cfg` are what we expect.
+    let plugin_cfg_string = read_to_string(plugin_cfg_path)?;
+    let plugin_cfg_split = plugin_cfg_string.split("\r\n").collect::<Vec<&str>>();
+    assert_eq!(plugin_cfg_split[0], "[plugin]");
+    assert_eq!(plugin_cfg_split[1], "name = \"Directory Browser\"");
+    assert_eq!(plugin_cfg_split[5], "script = \"directory_browser.gdns\"");
 
-    set_current_dir("../").expect("Unable to change to parent directory");
+    // 7. Assert that the plugin's gdns file exists.
+    let plugin_gdns_path = Path::new("platformer/addons/directory_browser/directory_browser.gdns");
+    assert_eq!(plugin_gdns_path.exists(), true);
+
+    // 8. Assert that the contents of the plugin's gdns file are what we expect.
+    let plugin_gdns_string = read_to_string(plugin_gdns_path)?;
+    let plugin_gdns_split = plugin_gdns_string.split("\r\n").collect::<Vec<&str>>();
+    assert_eq!(plugin_gdns_split[2], "[ext_resource path=\"res://addons/directory_browser/directory_browser.gdnlib\" type=\"GDNativeLibrary\" id=1]");
+    assert_eq!(plugin_gdns_split[6], "resource_name = \"DirectoryBrowser\"");
+    assert_eq!(plugin_gdns_split[7], "class_name = \"DirectoryBrowser\"");
+
+    // 9. Assert that the plugin's gdnlib file exists.
+    let plugin_gdnlib_path =
+        Path::new("platformer/addons/directory_browser/directory_browser.gdnlib");
+    assert_eq!(plugin_gdnlib_path.exists(), true);
+
+    // 10. Assert that the contents of the plugin's gdnlib file are what we expect.
+    let plugin_gdnlib_string = read_to_string(plugin_gdnlib_path)?;
+    let plugin_gdnlib_split = plugin_gdnlib_string.split("\r\n").collect::<Vec<&str>>();
+    assert_eq!(
+        plugin_gdnlib_split[9],
+        "OSX.64=\"res://addons/directory_browser/bin/libdirectory_browser.dylib\""
+    );
+    assert_eq!(
+        plugin_gdnlib_split[10],
+        "Windows.64=\"res://addons/directory_browser/bin/directory_browser.dll\""
+    );
+    assert_eq!(
+        plugin_gdnlib_split[11],
+        "X11.64=\"res://addons/directory_browser/bin/libdirectory_browser.so\""
+    );
 
     cleanup_test_files();
 
     Ok(())
 }
 
+/// Creates a plugin and then creates a module within the plugin and checks to
+/// make sure the module is added to the library.
 #[test]
-fn plugin_destroy_create_three_modules_and_two_plugins_remove_one_module_and_one_plugin(
-) -> Result<(), Box<dyn Error>> {
+fn plugin_create_module_library_structure() -> Result<(), Box<dyn Error>> {
     init_test();
 
-    let mut cmd = Command::cargo_bin("godot-rust-cli")?;
-    cmd.arg("new")
-        .arg("platformer_modules")
+    // 1. Assert that the plugin command was successful.
+    let mut cmd_plugin = Command::new("cargo");
+    cmd_plugin
+        .arg("run")
+        .arg("--manifest-path=../Cargo.toml")
+        .arg("new")
+        .arg("Directory Browser")
         .arg("platformer")
+        .arg("--plugin")
         .arg("--skip-build");
+    cmd_plugin.assert().success();
 
-    cmd.assert().success();
+    set_current_dir("directory_browser")?;
 
-    set_current_dir("platformer_modules").expect("Unable to change to library directory");
-    Command::new("cargo")
+    // 2. Assert the create module command was successful.
+    let mut cmd_create = Command::new("cargo");
+    cmd_create
         .arg("run")
         .arg("--manifest-path=../../Cargo.toml")
         .arg("create")
-        .arg("Player")
-        .output()
-        .expect("Unable to execute cargo run");
-    Command::new("cargo")
-        .arg("run")
-        .arg("--manifest-path=../../Cargo.toml")
-        .arg("create")
-        .arg("MainScene")
-        .output()
-        .expect("Unable to execute cargo run");
-    Command::new("cargo")
-        .arg("run")
-        .arg("--manifest-path=../../Cargo.toml")
-        .arg("create")
-        .arg("Ship")
-        .output()
-        .expect("Unable to execute cargo run");
-    Command::new("cargo")
-        .arg("run")
-        .arg("--manifest-path=../../Cargo.toml")
-        .arg("plugin")
-        .arg("File Parser")
-        .output()
-        .expect("Unable to execute cargo run");
-    Command::new("cargo")
-        .arg("run")
-        .arg("--manifest-path=../../Cargo.toml")
-        .arg("plugin")
-        .arg("Directory Browser")
-        .output()
-        .expect("Unable to execute cargo run");
-    Command::new("cargo")
-        .arg("run")
-        .arg("--manifest-path=../../Cargo.toml")
-        .arg("destroy")
-        .arg("Ship")
-        .output()
-        .expect("Unable to execute cargo run");
-    Command::new("cargo")
-        .arg("run")
-        .arg("--manifest-path=../../Cargo.toml")
-        .arg("destroy")
-        .arg("Directory Browser")
-        .output()
-        .expect("Unable to execute cargo run");
+        .arg("Explorer");
+    cmd_create.assert().success();
 
-    let lib_file = read_to_string("src/lib.rs").expect("Unable to read lib file");
-    let lib_file_split = lib_file.split("\n").collect::<Vec<&str>>();
+    // 3: Assert that the config includes the new module.
+    let config = read_to_string("godot-rust-cli.json")?;
+    let config_json: Value = serde_json::from_str(&config)?;
+    assert_eq!(
+        config_json["modules"],
+        json!(["Directory Browser", "Explorer"])
+    );
 
-    let config = read_to_string("godot-rust-cli.json").expect("Unable to read config");
-    let v: Value = serde_json::from_str(&config)?;
+    // 4. Assert that the plugin module has a mod file.
+    let module_path = Path::new("src/explorer.rs");
+    assert_eq!(module_path.exists(), true);
 
-    let player_mod_file_path = Path::new("src/player.rs");
-    let main_scene_mod_file_path = Path::new("src/main_scene.rs");
-    let ship_mod_file_path = Path::new("src/ship.rs");
-    let file_parser_mod_file_path = Path::new("src/file_parser.rs");
-    let directory_browser_mod_file_path = Path::new("src/directory_browser.rs");
+    // 5. Assert that the contents of the module's file matches the initial tool module.
+    let module_string = read_to_string(module_path)?;
+    let module_split = module_string.split("\n").collect::<Vec<&str>>();
+    assert_eq!(module_split[0], "use gdnative::api::EditorPlugin;");
+    assert_eq!(
+        module_split[5],
+        "#[user_data(user_data::LocalCellData<Explorer>)]"
+    );
+    assert_eq!(module_split[6], "pub struct Explorer;");
+    assert_eq!(module_split[9], "impl Explorer {");
+    assert_eq!(module_split[11].trim(), "Explorer");
 
-    let player_gdns_file = Path::new("../platformer/rust_modules/player.gdns");
-    let main_scene_gdns_file = Path::new("../platformer/rust_modules/main_scene.gdns");
-    let ship_gdns_file = Path::new("../platformer/rust_modules/ship.gdns");
-    let file_parser_gdns_file = Path::new("../platformer/rust_modules/file_parser.gdns");
-    let directory_browser_gdns_file =
-        Path::new("../platformer/rust_modules/directory_browser.gdns");
-
-    let file_parser_godot_plugin_dir = Path::new("../platformer/addons/file_parser");
-    let directory_browser_godot_plugin_dir = Path::new("../platformer/addons/directory_browser");
-
-    assert_eq!(lib_file_split[0], "mod file_parser;");
-    assert_eq!(lib_file_split[1], "mod main_scene;");
-    assert_eq!(lib_file_split[2], "mod player;");
-    assert_eq!(lib_file_split[3], "use gdnative::prelude::*;");
-    assert_eq!(lib_file_split[4], "");
-    assert_eq!(lib_file_split[5], "fn init(handle: InitHandle) {");
+    // 6. Assert that the module is added to the lib file.
+    let lib_file_string = read_to_string("src/lib.rs")?;
+    let lib_file_split = lib_file_string.split("\n").collect::<Vec<&str>>();
+    assert_eq!(lib_file_split[0], "mod directory_browser;");
+    assert_eq!(lib_file_split[1], "mod explorer;");
+    assert_eq!(
+        lib_file_split[5].trim(),
+        "handle.add_tool_class::<directory_browser::DirectoryBrowser>();"
+    );
     assert_eq!(
         lib_file_split[6].trim(),
-        "handle.add_class::<player::Player>();"
+        "handle.add_tool_class::<explorer::Explorer>();"
     );
+
+    set_current_dir("../")?;
+
+    cleanup_test_files();
+
+    Ok(())
+}
+
+/// Creates a plugin and then creates a module within the plugin and checks to
+/// make sure the module is added to Godot project.
+#[test]
+fn plugin_create_module_godot_structure() -> Result<(), Box<dyn Error>> {
+    init_test();
+
+    // 1. Assert that the plugin command was successful.
+    let mut cmd_plugin = Command::new("cargo");
+    cmd_plugin
+        .arg("run")
+        .arg("--manifest-path=../Cargo.toml")
+        .arg("new")
+        .arg("Directory Browser")
+        .arg("platformer")
+        .arg("--plugin")
+        .arg("--skip-build");
+    cmd_plugin.assert().success();
+
+    set_current_dir("directory_browser")?;
+
+    // 2. Assert the create module command was successful.
+    let mut cmd_create = Command::new("cargo");
+    cmd_create
+        .arg("run")
+        .arg("--manifest-path=../../Cargo.toml")
+        .arg("create")
+        .arg("Explorer");
+    cmd_create.assert().success();
+
+    // 3. Assert the build command was successful.
+    let mut cmd_build = Command::new("cargo");
+    cmd_build
+        .arg("run")
+        .arg("--manifest-path=../../Cargo.toml")
+        .arg("build");
+    cmd_build.assert().success();
+
+    set_current_dir("../")?;
+
+    // 3. Assert that the dynamic library for the plugin exists in the plugin's bin directory.
+    let plugin_dynamic_library_name = format!(
+        "platformer/addons/directory_browser/bin/{}directory_browser.{}",
+        BUILD_FILE_PREFIX, BUILD_FILE_TYPE
+    );
+    let plugin_dynamic_library_path = Path::new(&plugin_dynamic_library_name);
+    assert_eq!(plugin_dynamic_library_path.exists(), true);
+
+    // 4. Assert that the plugin's gdns file exists.
+    let module_gdns_path =
+        Path::new("platformer/addons/directory_browser/rust_modules/explorer.gdns");
+    assert_eq!(module_gdns_path.exists(), true);
+
+    // 8. Assert that the contents of the plugin's gdns file are what we expect.
+    let module_gdns_string = read_to_string(module_gdns_path)?;
+    let module_gdns_split = module_gdns_string.split("\r\n").collect::<Vec<&str>>();
+    assert_eq!(module_gdns_split[2], "[ext_resource path=\"res://addons/directory_browser/directory_browser.gdnlib\" type=\"GDNativeLibrary\" id=1]");
+    assert_eq!(module_gdns_split[6], "resource_name = \"Explorer\"");
+    assert_eq!(module_gdns_split[7], "class_name = \"Explorer\"");
+
+    cleanup_test_files();
+
+    Ok(())
+}
+
+/// Creates a plugin and then creates a module within the plugin and lastly
+/// deletes the module and checks the library structure.
+#[test]
+fn plugin_destroy_module_library_structure() -> Result<(), Box<dyn Error>> {
+    init_test();
+
+    // 1. Assert that the plugin command was successful.
+    let mut cmd_plugin = Command::new("cargo");
+    cmd_plugin
+        .arg("run")
+        .arg("--manifest-path=../Cargo.toml")
+        .arg("new")
+        .arg("Directory Browser")
+        .arg("platformer")
+        .arg("--plugin")
+        .arg("--skip-build");
+    cmd_plugin.assert().success();
+
+    set_current_dir("directory_browser")?;
+
+    // 2. Assert the create module command was successful.
+    let mut cmd_create = Command::new("cargo");
+    cmd_create
+        .arg("run")
+        .arg("--manifest-path=../../Cargo.toml")
+        .arg("create")
+        .arg("Explorer");
+    cmd_create.assert().success();
+
+    // 3: Assert that the config includes the new module.
+    let config = read_to_string("godot-rust-cli.json")?;
+    let config_json: Value = serde_json::from_str(&config)?;
     assert_eq!(
-        lib_file_split[7].trim(),
-        "handle.add_tool_class::<file_parser::FileParser>();"
+        config_json["modules"],
+        json!(["Directory Browser", "Explorer"])
     );
+
+    // 4. Assert that the destroy module command was successful.
+    let mut cmd_destroy = Command::new("cargo");
+    cmd_destroy
+        .arg("run")
+        .arg("--manifest-path=../../Cargo.toml")
+        .arg("destroy")
+        .arg("Explorer");
+    cmd_destroy.assert().success();
+
+    // 4. Assert that the plugin module no longer has a mod file.
+    let module_path = Path::new("src/explorer.rs");
+    assert_eq!(module_path.exists(), false);
+
+    // 5. Assert that the module is removed from the lib file.
+    let lib_file_string = read_to_string("src/lib.rs")?;
+    let lib_file_split = lib_file_string.split("\n").collect::<Vec<&str>>();
+    assert_eq!(lib_file_split[0], "mod directory_browser;");
     assert_eq!(
-        lib_file_split[8].trim(),
-        "handle.add_class::<main_scene::MainScene>();"
+        lib_file_split[4].trim(),
+        "handle.add_tool_class::<directory_browser::DirectoryBrowser>();"
     );
-    assert_eq!(lib_file_split[9], "}");
-    assert_eq!(lib_file_split[10], "");
-    assert_eq!(lib_file_split[11], "godot_init!(init);");
 
-    assert_eq!(v["modules"], json!(["Player", "MainScene", "FileParser"]));
+    set_current_dir("../")?;
 
-    assert_eq!(player_mod_file_path.exists(), true);
-    assert_eq!(main_scene_mod_file_path.exists(), true);
-    assert_eq!(file_parser_mod_file_path.exists(), true);
-    assert_eq!(directory_browser_mod_file_path.exists(), false);
-    assert_eq!(ship_mod_file_path.exists(), false);
+    cleanup_test_files();
 
-    assert_eq!(player_gdns_file.exists(), true);
-    assert_eq!(main_scene_gdns_file.exists(), true);
-    assert_eq!(file_parser_gdns_file.exists(), true);
-    assert_eq!(directory_browser_gdns_file.exists(), false);
-    assert_eq!(ship_gdns_file.exists(), false);
+    Ok(())
+}
 
-    assert_eq!(file_parser_godot_plugin_dir.exists(), true);
-    assert_eq!(directory_browser_godot_plugin_dir.exists(), false);
+/// Creates a plugin and then creates a module within the plugin and lastly
+/// deletes the module and checks the Godot project structure.
+#[test]
+fn plugin_destroy_module_godot_structure() -> Result<(), Box<dyn Error>> {
+    init_test();
 
-    set_current_dir("../").expect("Unable to change to parent directory");
+    // 1. Assert that the plugin command was successful.
+    let mut cmd_plugin = Command::new("cargo");
+    cmd_plugin
+        .arg("run")
+        .arg("--manifest-path=../Cargo.toml")
+        .arg("new")
+        .arg("Directory Browser")
+        .arg("platformer")
+        .arg("--plugin")
+        .arg("--skip-build");
+    cmd_plugin.assert().success();
+
+    set_current_dir("directory_browser")?;
+
+    // 2. Assert the create module command was successful.
+    let mut cmd_create = Command::new("cargo");
+    cmd_create
+        .arg("run")
+        .arg("--manifest-path=../../Cargo.toml")
+        .arg("create")
+        .arg("Explorer");
+    cmd_create.assert().success();
+
+    // 3. Assert the destroy module command was successful.
+    let mut cmd_destroy = Command::new("cargo");
+    cmd_destroy
+        .arg("run")
+        .arg("--manifest-path=../../Cargo.toml")
+        .arg("destroy")
+        .arg("Explorer");
+    cmd_destroy.assert().success();
+
+    set_current_dir("../")?;
+
+    // 4. Assert that the plugin's gdns file no longer exists.
+    let module_gdns_path =
+        Path::new("platformer/addons/directory_browser/rust_modules/explorer.gdns");
+    assert_eq!(module_gdns_path.exists(), false);
 
     cleanup_test_files();
 

--- a/tests/command-plugin.rs
+++ b/tests/command-plugin.rs
@@ -47,7 +47,10 @@ fn plugin_create_library_structure() -> Result<(), Box<dyn Error>> {
 
     // 5. Assert that the contents of the plugin's initial module matches the initial tool module.
     let plugin_module_string = read_to_string(plugin_module_path)?;
-    let plugin_module_split = plugin_module_string.split("\n").collect::<Vec<&str>>();
+    let plugin_module_split = plugin_module_string
+        .split("\n")
+        .map(|x| x.replace("\r", ""))
+        .collect::<Vec<String>>();
     assert_eq!(plugin_module_split[0], "use gdnative::api::EditorPlugin;");
     assert_eq!(
         plugin_module_split[5],
@@ -63,7 +66,10 @@ fn plugin_create_library_structure() -> Result<(), Box<dyn Error>> {
 
     // 7. Assert that the plugin's initial module is added to the lib file.
     let lib_file_string = read_to_string(lib_file_path)?;
-    let lib_file_split = lib_file_string.split("\n").collect::<Vec<&str>>();
+    let lib_file_split = lib_file_string
+        .split("\n")
+        .map(|x| x.replace("\r", ""))
+        .collect::<Vec<String>>();
     assert_eq!(lib_file_split[0], "mod directory_browser;");
     assert_eq!(
         lib_file_split[4].trim(),
@@ -115,7 +121,10 @@ fn plugin_create_godot_structure() -> Result<(), Box<dyn Error>> {
 
     // 6. Assert that the contents of the `plugin.cfg` are what we expect.
     let plugin_cfg_string = read_to_string(plugin_cfg_path)?;
-    let plugin_cfg_split = plugin_cfg_string.split("\n").collect::<Vec<&str>>();
+    let plugin_cfg_split = plugin_cfg_string
+        .split("\n")
+        .map(|x| x.replace("\r", ""))
+        .collect::<Vec<String>>();
     assert_eq!(plugin_cfg_split[0], "[plugin]");
     assert_eq!(plugin_cfg_split[1], "name = \"Directory Browser\"");
     assert_eq!(plugin_cfg_split[5], "script = \"directory_browser.gdns\"");
@@ -126,7 +135,10 @@ fn plugin_create_godot_structure() -> Result<(), Box<dyn Error>> {
 
     // 8. Assert that the contents of the plugin's gdns file are what we expect.
     let plugin_gdns_string = read_to_string(plugin_gdns_path)?;
-    let plugin_gdns_split = plugin_gdns_string.split("\n").collect::<Vec<&str>>();
+    let plugin_gdns_split = plugin_gdns_string
+        .split("\n")
+        .map(|x| x.replace("\r", ""))
+        .collect::<Vec<String>>();
     assert_eq!(plugin_gdns_split[2], "[ext_resource path=\"res://addons/directory_browser/directory_browser.gdnlib\" type=\"GDNativeLibrary\" id=1]");
     assert_eq!(plugin_gdns_split[6], "resource_name = \"DirectoryBrowser\"");
     assert_eq!(plugin_gdns_split[7], "class_name = \"DirectoryBrowser\"");
@@ -138,7 +150,10 @@ fn plugin_create_godot_structure() -> Result<(), Box<dyn Error>> {
 
     // 10. Assert that the contents of the plugin's gdnlib file are what we expect.
     let plugin_gdnlib_string = read_to_string(plugin_gdnlib_path)?;
-    let plugin_gdnlib_split = plugin_gdnlib_string.split("\n").collect::<Vec<&str>>();
+    let plugin_gdnlib_split = plugin_gdnlib_string
+        .split("\n")
+        .map(|x| x.replace("\r", ""))
+        .collect::<Vec<String>>();
     assert_eq!(
         plugin_gdnlib_split[9],
         "OSX.64=\"res://addons/directory_browser/bin/libdirectory_browser.dylib\""
@@ -197,7 +212,10 @@ fn plugin_create_module_library_structure() -> Result<(), Box<dyn Error>> {
 
     // 5. Assert that the contents of the module's file matches the initial tool module.
     let module_string = read_to_string(module_path)?;
-    let module_split = module_string.split("\n").collect::<Vec<&str>>();
+    let module_split = module_string
+        .split("\n")
+        .map(|x| x.replace("\r", ""))
+        .collect::<Vec<String>>();
     assert_eq!(module_split[0], "use gdnative::api::EditorPlugin;");
     assert_eq!(
         module_split[5],
@@ -209,7 +227,10 @@ fn plugin_create_module_library_structure() -> Result<(), Box<dyn Error>> {
 
     // 6. Assert that the module is added to the lib file.
     let lib_file_string = read_to_string("src/lib.rs")?;
-    let lib_file_split = lib_file_string.split("\n").collect::<Vec<&str>>();
+    let lib_file_split = lib_file_string
+        .split("\n")
+        .map(|x| x.replace("\r", ""))
+        .collect::<Vec<String>>();
     assert_eq!(lib_file_split[0], "mod directory_browser;");
     assert_eq!(lib_file_split[1], "mod explorer;");
     assert_eq!(
@@ -282,7 +303,10 @@ fn plugin_create_module_godot_structure() -> Result<(), Box<dyn Error>> {
 
     // 8. Assert that the contents of the plugin's gdns file are what we expect.
     let module_gdns_string = read_to_string(module_gdns_path)?;
-    let module_gdns_split = module_gdns_string.split("\n").collect::<Vec<&str>>();
+    let module_gdns_split = module_gdns_string
+        .split("\n")
+        .map(|x| x.replace("\r", ""))
+        .collect::<Vec<String>>();
     assert_eq!(module_gdns_split[2], "[ext_resource path=\"res://addons/directory_browser/directory_browser.gdnlib\" type=\"GDNativeLibrary\" id=1]");
     assert_eq!(module_gdns_split[6], "resource_name = \"Explorer\"");
     assert_eq!(module_gdns_split[7], "class_name = \"Explorer\"");
@@ -346,7 +370,10 @@ fn plugin_destroy_module_library_structure() -> Result<(), Box<dyn Error>> {
 
     // 5. Assert that the module is removed from the lib file.
     let lib_file_string = read_to_string("src/lib.rs")?;
-    let lib_file_split = lib_file_string.split("\n").collect::<Vec<&str>>();
+    let lib_file_split = lib_file_string
+        .split("\n")
+        .map(|x| x.replace("\r", ""))
+        .collect::<Vec<String>>();
     assert_eq!(lib_file_split[0], "mod directory_browser;");
     assert_eq!(
         lib_file_split[4].trim(),

--- a/tests/test_utilities.rs
+++ b/tests/test_utilities.rs
@@ -23,6 +23,10 @@ pub const BUILD_FILE_PREFIX: &str = "";
 
 /// If the tests are being run on linux, then the build file prefix is lib.
 #[cfg(target_os = "linux")]
+#[allow(dead_code)]
+pub const BUILD_FILE_PREFIX: &str = "lib";
+
+/// If the tests are being run on macos, then the build file prefix is lib.
 #[cfg(target_os = "macos")]
 #[allow(dead_code)]
 pub const BUILD_FILE_PREFIX: &str = "lib";

--- a/tests/test_utilities.rs
+++ b/tests/test_utilities.rs
@@ -16,59 +16,86 @@ pub const BUILD_FILE_NAME: &str = "libplatformer_modules.so";
 #[allow(dead_code)]
 pub const BUILD_FILE_NAME: &str = "libplatformer_modules.dylib";
 
+/// If the tests are being run on windows, then there is no build file prefix.
+#[cfg(target_os = "windows")]
+#[allow(dead_code)]
+pub const BUILD_FILE_PREFIX: &str = "";
+
+/// If the tests are being run on linux, then the build file prefix is lib.
+#[cfg(target_os = "linux")]
+#[cfg(target_os = "macos")]
+#[allow(dead_code)]
+pub const BUILD_FILE_PREFIX: &str = "lib";
+
+/// If the tests are being run on windows, then the build file type is a dll file.
+#[cfg(target_os = "windows")]
+#[allow(dead_code)]
+pub const BUILD_FILE_TYPE: &str = "dll";
+
+/// If the tests are being run on linux, then the build file type is a .so file.
+#[cfg(target_os = "linux")]
+#[allow(dead_code)]
+pub const BUILD_FILE_TYPE: &str = "so";
+
+/// If the tests are being run on macos, then the build file is type a .dylib file.
+#[cfg(target_os = "macos")]
+#[allow(dead_code)]
+pub const BUILD_FILE_TYPE: &str = "dylib";
+
 /// Some tests need to change directory to run correctly so this function is
 /// called after those tests to go back to the tests directory that every
 /// function expects to be in.
 #[allow(dead_code)]
 pub fn ensure_correct_dir() {
-  let current_dir = std::env::current_dir().unwrap();
-  let current_dir_basename = current_dir.file_stem().unwrap();
+    let current_dir = std::env::current_dir().unwrap();
+    let current_dir_basename = current_dir.file_stem().unwrap();
 
-  if current_dir_basename != "tests" {
-    std::env::set_current_dir("tests").expect("Unable to change to tests directory");
-  }
+    if current_dir_basename != "tests" {
+        std::env::set_current_dir("tests").expect("Unable to change to tests directory");
+    }
 }
 
 /// Creates a folder with a project.godot file at the root to simulate the tests
 /// running on an actual Godot project.
 #[allow(dead_code)]
 pub fn create_godot_project() {
-  std::fs::create_dir("platformer").expect("Unable to create Godot project directory");
-  std::fs::File::create("platformer/project.godot").expect("Unable to create godot.project file");
+    std::fs::create_dir("platformer").expect("Unable to create Godot project directory");
+    std::fs::File::create("platformer/project.godot").expect("Unable to create godot.project file");
 }
 
 /// Since tests create folders and files we need to remove them before running
 /// the next tests.
 #[allow(dead_code)]
 pub fn cleanup_test_files() {
-  if Path::new("platformer").exists() {
-    remove_dir_all("platformer").expect("Unable to remove Godot project dir");
-  }
-
-  if Path::new("platformer_modules").exists() {
-    remove_dir_all("platformer_modules").expect("Unable to remove library dir");
-  }
-
-  if Path::new("directory_browser").exists() {
-    remove_dir_all("directory_browser").expect("Unable to remove plugin dir");
-  }
-
-  if Path::new("platformer/platformer_modules.gdnlib").exists() {
-    remove_file("platformer/platformer_modules.gdnlib").expect("Unable to remove gdnlib file");
-    if Path::new("platformer/platformer_modules.dll").exists() {
-      remove_file("platformer/platformer_modules.dll").expect("Unable to remove dll file");
+    if Path::new("platformer").exists() {
+        remove_dir_all("platformer").expect("Unable to remove Godot project dir");
     }
-    if Path::new("platformer/libplatformer_modules.so").exists() {
-      remove_file("platformer/libplatformer_modules.so").expect("Unable to remove so file");
-    }
-    if Path::new("platformer/libplatformer_modules.dylib").exists() {
-      remove_file("platformer/libplatformer_modules.dylib").expect("Unable to remove macos file");
-    }
-  }
 
-  if Path::new("platformer/addons").exists() {
-    remove_dir_all("platformer/addons").expect("Unable to remove plugin addons dir");
-  }
+    if Path::new("platformer_modules").exists() {
+        remove_dir_all("platformer_modules").expect("Unable to remove library dir");
+    }
+
+    if Path::new("directory_browser").exists() {
+        remove_dir_all("directory_browser").expect("Unable to remove plugin dir");
+    }
+
+    if Path::new("platformer/platformer_modules.gdnlib").exists() {
+        remove_file("platformer/platformer_modules.gdnlib").expect("Unable to remove gdnlib file");
+        if Path::new("platformer/platformer_modules.dll").exists() {
+            remove_file("platformer/platformer_modules.dll").expect("Unable to remove dll file");
+        }
+        if Path::new("platformer/libplatformer_modules.so").exists() {
+            remove_file("platformer/libplatformer_modules.so").expect("Unable to remove so file");
+        }
+        if Path::new("platformer/libplatformer_modules.dylib").exists() {
+            remove_file("platformer/libplatformer_modules.dylib")
+                .expect("Unable to remove macos file");
+        }
+    }
+
+    if Path::new("platformer/addons").exists() {
+        remove_dir_all("platformer/addons").expect("Unable to remove plugin addons dir");
+    }
 }
 
 /// Returns the path of the specified file.
@@ -78,30 +105,30 @@ pub fn cleanup_test_files() {
 /// `file_to_find` - The name of the file to find.
 #[allow(dead_code)]
 fn find_file(file_to_find: String) -> std::path::PathBuf {
-  let mut exists = false;
-  let current_dir = std::env::current_dir().expect("Unable to get current directory");
-  let mut dir_to_check = std::path::Path::new(&current_dir);
-  let mut iterations = 0;
+    let mut exists = false;
+    let current_dir = std::env::current_dir().expect("Unable to get current directory");
+    let mut dir_to_check = std::path::Path::new(&current_dir);
+    let mut iterations = 0;
 
-  while !exists && iterations <= 10 {
-    let temp_path = std::path::Path::new(&dir_to_check).join(&file_to_find);
-    exists = temp_path.exists();
+    while !exists && iterations <= 10 {
+        let temp_path = std::path::Path::new(&dir_to_check).join(&file_to_find);
+        exists = temp_path.exists();
 
-    if !exists {
-      iterations += 1;
-      dir_to_check = dir_to_check
-        .parent()
-        .expect("Unable to get parent directory");
+        if !exists {
+            iterations += 1;
+            dir_to_check = dir_to_check
+                .parent()
+                .expect("Unable to get parent directory");
+        }
     }
-  }
 
-  return dir_to_check.to_owned();
+    return dir_to_check.to_owned();
 }
 
 /// Runs before each test.
 #[allow(dead_code)]
 pub fn init_test() {
-  ensure_correct_dir();
-  cleanup_test_files();
-  create_godot_project();
+    ensure_correct_dir();
+    cleanup_test_files();
+    create_godot_project();
 }


### PR DESCRIPTION
- Plugins are now their own library.
- When you create plugin, it creates a module for it automatically. This module is not a standard module so it can't be destroyed.
- All modules created for a plugin will be tool scripts.