### PR TITLE
Added tests for debug and release builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,12 +250,13 @@ Builds the library to generate the dynamic libraries and then copies them to the
 **Usage:**
 
 ```sh
-godot-rust-cli build [--w, --watch]
+godot-rust-cli build [--w, --watch] [-r, --release]
 ```
 
 where:
 
 - `w, --watch` can be passed optionally to have Godot Rust CLI watch the library for changes and rebuild automatically.
+- `r, --release` can be passed optionally to create a release build instead of the default debug build.
 
 **Examples:**
 

--- a/tests/command-build.rs
+++ b/tests/command-build.rs
@@ -9,6 +9,113 @@ mod test_utilities;
 use test_utilities::{cleanup_test_files, init_test};
 
 /// Creates a library and a module and runs the build command ands checks to
+/// make sure that the default debug build was created.
+#[test]
+fn build_default_to_debug_build() -> Result<(), Box<dyn Error>> {
+    init_test();
+
+    // 1. Assert that the new command was successful.
+    let mut cmd_new = Command::new("cargo");
+    cmd_new
+        .arg("run")
+        .arg("--manifest-path=../Cargo.toml")
+        .arg("new")
+        .arg("PlatformerModules")
+        .arg("platformer")
+        .arg("--skip-build");
+    cmd_new.assert().success();
+
+    set_current_dir("platformer_modules")?;
+
+    // 2. Assert that the create command was successful.
+    let mut cmd_create = Command::new("cargo");
+    cmd_create
+        .arg("run")
+        .arg("--manifest-path=../../Cargo.toml")
+        .arg("create")
+        .arg("Player");
+    cmd_create.assert().success();
+
+    // 3. Assert that the build command was successful.
+    let mut cmd_build = Command::new("cargo");
+    cmd_build
+        .arg("run")
+        .arg("--manifest-path=../../Cargo.toml")
+        .arg("build");
+    cmd_build.assert().success();
+
+    // 4. Assert the path to the debug build of the dynamic library is correct.
+    let dynamic_library_debug_path = format!(
+        "target/{}/debug//{}platformer_modules{}",
+        env!("TARGET"),
+        std::env::consts::DLL_PREFIX,
+        std::env::consts::DLL_SUFFIX
+    );
+
+    assert_eq!(Path::new(&dynamic_library_debug_path).exists(), true);
+
+    set_current_dir("../")?;
+
+    cleanup_test_files();
+
+    Ok(())
+}
+
+/// Creates a library and a module and runs the build command with the release
+/// flag ands checks to make sure that the release build was created.
+#[test]
+fn build_create_release_build() -> Result<(), Box<dyn Error>> {
+    init_test();
+
+    // 1. Assert that the new command was successful.
+    let mut cmd_new = Command::new("cargo");
+    cmd_new
+        .arg("run")
+        .arg("--manifest-path=../Cargo.toml")
+        .arg("new")
+        .arg("PlatformerModules")
+        .arg("platformer")
+        .arg("--skip-build");
+    cmd_new.assert().success();
+
+    set_current_dir("platformer_modules")?;
+
+    // 2. Assert that the create command was successful.
+    let mut cmd_create = Command::new("cargo");
+    cmd_create
+        .arg("run")
+        .arg("--manifest-path=../../Cargo.toml")
+        .arg("create")
+        .arg("Player");
+    cmd_create.assert().success();
+
+    // 3. Assert that the build command was successful.
+    let mut cmd_build = Command::new("cargo");
+    cmd_build
+        .arg("run")
+        .arg("--manifest-path=../../Cargo.toml")
+        .arg("build")
+        .arg("--release");
+    cmd_build.assert().success();
+
+    // 4. Assert the path to the debug build of the dynamic library is correct.
+    let dynamic_library_debug_path = format!(
+        "target/{}/release//{}platformer_modules{}",
+        env!("TARGET"),
+        std::env::consts::DLL_PREFIX,
+        std::env::consts::DLL_SUFFIX
+    );
+
+    assert_eq!(Path::new(&dynamic_library_debug_path).exists(), true);
+
+    set_current_dir("../")?;
+
+    cleanup_test_files();
+
+    Ok(())
+}
+
+/// Creates a library and a module and runs the build command ands checks to
 /// make sure that the dynamic library was created and copied to the Godot
 /// project.
 #[test]

--- a/tests/command-platform.rs
+++ b/tests/command-platform.rs
@@ -158,9 +158,9 @@ fn platform_add_windows_platform_twice() -> Result<(), Box<dyn Error>> {
 }
 
 /// Creates a library and adds windows as a supported platform that the library
-/// can be built for and then builds the library.
+/// can be built for and then builds the default debug build.
 #[test]
-fn platform_add_windows_platform_and_build() -> Result<(), Box<dyn Error>> {
+fn platform_add_windows_platform_and_build_default_debug() -> Result<(), Box<dyn Error>> {
     init_test();
 
     // 1. Assert that the new command was successful.
@@ -194,33 +194,68 @@ fn platform_add_windows_platform_and_build() -> Result<(), Box<dyn Error>> {
         .arg("--all");
     cmd_build_all.assert().success();
 
-    // 4. Assert that the config contains the added platform.
-    let config = read_to_string("godot-rust-cli.json")?;
-    let config_json: Value = serde_json::from_str(&config)?;
-    assert_eq!(config_json["platforms"], json!(["windows"]));
+    // 4. Assert the default debug build was created.
+    let dynamic_library_debug_path =
+        Path::new("target/x86_64-pc-windows-gnu/debug/platformer_modules.dll");
+    assert_eq!(dynamic_library_debug_path.exists(), true);
 
-    // 5. Since the windows platform needs a custom docker image we want to
-    // make sure that the docker image was copied over.
-    let windows_docker_file_path = Path::new("docker/Dockerfile.x86_64-pc-windows-gnu");
-    assert_eq!(windows_docker_file_path.exists(), true);
+    // 5. Assert that the dll file was copied to the Godot project.
+    let godot_project_dll_path =
+        Path::new("../platformer/gdnative/bin/windows/platformer_modules.dll");
+    assert_eq!(godot_project_dll_path.exists(), true);
 
-    // 6. Assert that the Cross.toml file exists and that its contents are what
-    // we expect.
-    let cross_config_file_path = Path::new("Cross.toml");
-    assert_eq!(cross_config_file_path.exists(), true);
+    set_current_dir("../")?;
 
-    let cross_config_string = read_to_string(&cross_config_file_path)?;
-    let cross_config_split = cross_config_string
-        .split("\n")
-        .map(|x| x.replace("\r", ""))
-        .collect::<Vec<String>>();
-    assert_eq!(cross_config_split[0], "[target.x86_64-pc-windows-gnu]");
-    assert_eq!(
-        cross_config_split[1],
-        "image = \"godot-rust-cli-platform-windows:v1\""
-    );
+    cleanup_docker_images();
+    cleanup_test_files();
 
-    // 7. Assert that the dll file was copied to the Godot project.
+    Ok(())
+}
+
+/// Creates a library and adds windows as a supported platform that the library
+/// can be built for and then builds the release build.
+#[test]
+fn platform_add_windows_platform_and_build_release() -> Result<(), Box<dyn Error>> {
+    init_test();
+
+    // 1. Assert that the new command was successful.
+    let mut cmd_new_library = Command::new("cargo");
+    cmd_new_library
+        .arg("run")
+        .arg("--manifest-path=../Cargo.toml")
+        .arg("new")
+        .arg("PlatformerModules")
+        .arg("platformer")
+        .arg("--skip-build");
+    cmd_new_library.assert().success();
+
+    set_current_dir("platformer_modules")?;
+
+    // 2. Assert that the add platform command was successful.
+    let mut cmd_add_platform = Command::new("cargo");
+    cmd_add_platform
+        .arg("run")
+        .arg("--manifest-path=../../Cargo.toml")
+        .arg("add-platform")
+        .arg("windows");
+    cmd_add_platform.assert().success();
+
+    // 3. Assert the build --all command was successful.
+    let mut cmd_build_all = Command::new("cargo");
+    cmd_build_all
+        .arg("run")
+        .arg("--manifest-path=../../Cargo.toml")
+        .arg("build")
+        .arg("--release")
+        .arg("--all");
+    cmd_build_all.assert().success();
+
+    // 4. Assert the default release build was created.
+    let dynamic_library_release_path =
+        Path::new("target/x86_64-pc-windows-gnu/release/platformer_modules.dll");
+    assert_eq!(dynamic_library_release_path.exists(), true);
+
+    // 5. Assert that the dll file was copied to the Godot project.
     let godot_project_dll_path =
         Path::new("../platformer/gdnative/bin/windows/platformer_modules.dll");
     assert_eq!(godot_project_dll_path.exists(), true);


### PR DESCRIPTION
Related to issue #22 

- The `--release` flag can be specified to create a release build instead of the default debug build.