### PR TITLE
Set Main Workflow To Run Only On PR

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-on: [push, pull_request, workflow_dispatch]
+on: [pull_request]
 
 name: build-and-test
 


### PR DESCRIPTION
- Previously the main workflow was set to run on push and PR and it was running twice for PRs which was taking a lot of time. Now it will only run on PR.